### PR TITLE
Adjusted checks based on publish time

### DIFF
--- a/app.go
+++ b/app.go
@@ -138,7 +138,7 @@ func (listener PublishMessageListener) OnMessage(msg consumer.Message) error {
 		return nil
 	}
 
-	info.Printf("Message [%v] is VALID, scheduling checks...", tid)
+	info.Printf("Message [%v] is VALID.", tid)
 
 	publishDateString := msg.Headers["Message-Timestamp"]
 	publishDate, err := time.Parse(dateLayout, publishDateString)
@@ -146,6 +146,10 @@ func (listener PublishMessageListener) OnMessage(msg consumer.Message) error {
 		log.Printf("Cannot parse publish date [%v] from message [%v], error: [%v]",
 			publishDateString, tid, err.Error())
 		return nil
+	}
+
+	if isMessagePastPublishSLA(publishDate, appConfig.Threshold) {
+		info.Printf("Message [%v] is past publish SLA, skipping.", tid)
 	}
 
 	scheduleChecks(eomFile, publishDate)

--- a/scheduler.go
+++ b/scheduler.go
@@ -34,15 +34,23 @@ func scheduleChecks(eomFile EomFile, publishDate time.Time) {
 
 func scheduleCheck(check PublishCheck) {
 
-	quitChan := make(chan bool)
-	checkNr := 1
+	//the date the SLA expires for this publish event
+	publishSLA := check.Metric.publishDate.Add(time.Duration(check.Threshold) * time.Second)
+
+	//compute the actual seconds left until the SLA to compensate for the
+	//time passed between publish and the message reaching this point
+	secondsUntilSLA := publishSLA.Sub(time.Now()).Seconds()
 
 	//used to signal the ticker to stop after the threshold duration is reached
+	quitChan := make(chan bool)
 	go func() {
-		<-time.After(time.Duration(check.Threshold) * time.Second)
+		<-time.After(time.Duration(secondsUntilSLA) * time.Second)
 		close(quitChan)
 	}()
 
+	secondsSincePublish := time.Since(check.Metric.publishDate).Seconds()
+	elapsedIntervals := secondsSincePublish / float64(check.CheckInterval)
+	checkNr := int(elapsedIntervals) + 1
 	// ticker to fire once per interval
 	tickerChan := time.NewTicker(time.Duration(check.CheckInterval) * time.Second)
 	for {

--- a/scheduler.go
+++ b/scheduler.go
@@ -40,7 +40,7 @@ func scheduleCheck(check PublishCheck) {
 	//compute the actual seconds left until the SLA to compensate for the
 	//time passed between publish and the message reaching this point
 	secondsUntilSLA := publishSLA.Sub(time.Now()).Seconds()
-
+	info.Println("Seconds until SLA for [%v] : [%v]", check.Metric.UUID, secondsUntilSLA)
 	//used to signal the ticker to stop after the threshold duration is reached
 	quitChan := make(chan bool)
 	go func() {
@@ -49,7 +49,9 @@ func scheduleCheck(check PublishCheck) {
 	}()
 
 	secondsSincePublish := time.Since(check.Metric.publishDate).Seconds()
+	info.Printf("Seconds elapsed since publish for [%v] : [%v]", check.Metric.UUID, secondsSincePublish)
 	elapsedIntervals := secondsSincePublish / float64(check.CheckInterval)
+	info.Printf("Skipping first [%v] checks for [%v]", elapsedIntervals, check.Metric.UUID)
 	checkNr := int(elapsedIntervals) + 1
 	// ticker to fire once per interval
 	tickerChan := time.NewTicker(time.Duration(check.CheckInterval) * time.Second)

--- a/validator.go
+++ b/validator.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/base64"
 	"strings"
+	"time"
 
 	"github.com/Financial-Times/message-queue-gonsumer/consumer"
 	"github.com/satori/go.uuid"
@@ -25,6 +26,11 @@ const expectedWebTypePrefix = "digitalList"
 const expectedFilePathSuffix = ".xml"
 
 const syntheticPrefix = "SYNTHETIC"
+
+func isMessagePastPublishSLA(date time.Time, threshold int) bool {
+	passedSLA := date.Add(time.Duration(threshold) * time.Second)
+	return time.Now().After(passedSLA)
+}
 
 func isSyntheticMessage(tid string) bool {
 	return strings.HasPrefix(tid, syntheticPrefix)

--- a/validator_test.go
+++ b/validator_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/Financial-Times/message-queue-gonsumer/consumer"
 )
@@ -10,6 +11,20 @@ import (
 func TestMain(m *testing.M) {
 	initLogs(os.Stdout, os.Stdout, os.Stderr)
 	os.Exit(m.Run())
+}
+
+func TestIsMessagePastPublishSLA_pastSLA(t *testing.T) {
+	publishDate := time.Now().Add(-(threshold + 1) * time.Second)
+	if !isMessagePastPublishSLA(publishDate, threshold) {
+		t.Error("Did not detect message past SLA")
+	}
+}
+
+func TestIsMessagePastPublishSLA_notPastSLA(t *testing.T) {
+	publishDate := time.Now()
+	if isMessagePastPublishSLA(publishDate, threshold) {
+		t.Error("Valid message marked as passed SLA")
+	}
 }
 
 func TestIsSyntheticMessage_naturalMessage(t *testing.T) {
@@ -283,6 +298,7 @@ var invalidImageEomFile = EomFile{
 	"system attributes",
 }
 
+const threshold = 120
 const syntheticTID = "SYNTHETIC-REQ-MONe4d2885f-1140-400b-9407-921e1c7378cd"
 const naturalTID = "tid_xltcnbckvq"
 const validListAttributes = "<!DOCTYPE ObjectMetadata SYSTEM \"/SysConfig/Classify/FTDWC2/classify.dtd\"><ObjectMetadata>	<FTcom>		<DIFTcomWebType>digitalList</DIFTcomWebType></FTcom><Lists>		<Title>Editor's pick</Title><LayoutHint>standard</LayoutHint></Lists></ObjectMetadata>"


### PR DESCRIPTION
* adjusted implementation to take into account the time passed between the publish date and the moment we actually read the message
* we ignore messages for which the SLA has already passed by the time we process it