### PR TITLE
Keep 2GBs of logs

### DIFF
--- a/puppet/ft-publish_availability_monitor/templates/supervisord.conf.erb
+++ b/puppet/ft-publish_availability_monitor/templates/supervisord.conf.erb
@@ -6,8 +6,8 @@ port=9001
 
 [supervisord]
 logfile=<%=supervisord_log_dir%>/supervisord.log
-logfile_maxbytes=5MB
-logfile_backups=30
+logfile_maxbytes=100MB
+logfile_backups=20
 loglevel=info
 pidfile=/var/run/supervisord.pid
 childlogdir=/var/log/apps


### PR DESCRIPTION
Just for safety, in case they aren't indexed for a while. We have about 5GBs free on the machine so it should be ok.