### PR TITLE
Only defer closing the body when the http call is successful

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.html
 *coverage.*
 publish-availability-monitor
+.idea/

--- a/publishCheck.go
+++ b/publishCheck.go
@@ -62,13 +62,12 @@ func (pc PublishCheck) DoCheck() bool {
 	}
 
 	url := check.buildURL(pc.Metric)
-	// logging URL to catch a case where the URL is possibly invalid
-	info.Printf("Generated URL: [%v]", url)
 	resp, err := http.Get(url)
-	defer resp.Body.Close()
 	if err != nil {
+		warn.Printf("Error calling URL: [%v] : [%v]", url, err.Error())
 		return false
 	}
+	defer resp.Body.Close()
 
 	return check.isCurrentOperationFinished(pc.Metric, resp)
 }


### PR DESCRIPTION
* log error in case the HTTP call is not successful
* only close the body if the call was successfull, it's guaranteed that it's not null in this case