### PR TITLE
adding content to the notes field

### DIFF
--- a/puppet/ft-publish_availability_monitor/manifests/monitoring.pp
+++ b/puppet/ft-publish_availability_monitor/manifests/monitoring.pp
@@ -44,7 +44,7 @@ class publish_availability_monitor::monitoring {
     check_interval      => 1,
     action_url          => $action_url,
     notes_url           => $action_url,
-    notes               => "",
+    notes               => "Check that the message queue consumer is reachable.",
     service_description => "Check that the message queue consumer is reachable.",
     display_name        => "${hostname}_check_http_json",
     tag                 => $content_platform_nagios::client::tags_to_apply,


### PR DESCRIPTION
There is a bug with the version of Puppet running on FTP1 (2.7.1), which is unable to parse an empty 'notes' field in Nagios config.

The Puppet runs on the Nagios host do not fail, but instead continually re-add all services to the nagios_service.cfg file, causing it to blow up in size (750kb > 35mb!) with duplicate entries, and causing /var to run out of space due to the mass of duplicate resource entry warnings in the nagios.log.

This change will allow us to work around this bug.