### PR TITLE
Log publishOk=false if the SLA has already been exceeded.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *coverage.*
 publish-availability-monitor
 .idea/
+/.project

--- a/app.go
+++ b/app.go
@@ -193,6 +193,14 @@ func handleMessage(msg consumer.Message) {
 
 	if isMessagePastPublishSLA(publishDate, appConfig.Threshold) {
 		infoLogger.Printf("Message [%v] with UUID [%v] is past publish SLA, skipping.", tid, uuid)
+		// push a "not OK" metric
+		metricSink <- PublishMetric{
+			UUID:            uuid,
+			publishOK:       false,
+			publishDate:     publishDate,
+			publishInterval: Interval{appConfig.Threshold, appConfig.Threshold},
+			config:          MetricConfig{Alias: "any"},
+			tid:             tid}
 		return
 	}
 


### PR DESCRIPTION
If, for some reason, the receipt of a message into PAM is delayed by
more than the threshold, it does not attempt to monitor that item, but
then it isn't captured by the SLA alerts and dashboards. In this case we
can send a message with the negative result to the metrics channel
immediately.

Ignore Eclipse project files.