### PR TITLE
remove pointer

### DIFF
--- a/content/wordPressContent.go
+++ b/content/wordPressContent.go
@@ -18,7 +18,7 @@ type WordPressMessage struct {
 	Status      string `json:"status"`
 	APIURL      string `json:"apiUrl"`
 	Error       string `json:"error"`
-	Post        *Post  `json:"post"`
+	Post        Post   `json:"post"`
 	PreviousURL string `json:"previousUrl"`
 }
 

--- a/content/wordPressContent_test.go
+++ b/content/wordPressContent_test.go
@@ -19,5 +19,5 @@ var wordpressContentMarkedDeletedTrue = WordPressMessage{
 }
 
 var wordpressContentMarkedDeletedFalse = WordPressMessage{
-	Status: "ok", Post: &Post{},
+	Status: "ok", Post: Post{},
 }


### PR DESCRIPTION
making PAM not to panic next time in case of missing _post_ field: if it's not a pointer, default values will be used