### PR TITLE
Replace hard-coded version with semver token.

### DIFF
--- a/puppet/ft-publish_availability_monitor/Modulefile
+++ b/puppet/ft-publish_availability_monitor/Modulefile
@@ -1,5 +1,5 @@
 name    'ft-publish_availability_monitor'
-version '0.18.4'
+version '@semver@'
 source 'UNKNOWN'
 author 'ft'
 license 'Apache License, Version 2.0'


### PR DESCRIPTION
See changes to Jenkins build job for substitution of the token with the
Git tag.