### PR TITLE
Make host header configurable.

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -4,7 +4,7 @@
 		"address": ["QUEUE_ADDR"],
 		"group": "PubMonitor",
 		"topic": "NativeCmsPublicationEvents",
-		"queue": "kafka",
+		"queue": "KAFKA_PROXY_HOST",
 		"concurrentProcessing": true
 	},
 	"metricConfig": [{

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+sed -i "s KAFKA_PROXY_HOST $KAFKA_PROXY_HOST " /config.json
 sed -i "s QUEUE_ADDR $QUEUE_ADDR " /config.json
 sed -i "s S3_URL $S3_URL " /config.json
 sed -i "s CONTENT_URL $CONTENT_URL " /config.json


### PR DESCRIPTION
This seems to have different values between the publishing and delivery
clusters.