### PR TITLE
Don't send credentials to S3 endpoint.

### DIFF
--- a/publishCheck.go
+++ b/publishCheck.go
@@ -187,7 +187,7 @@ func parseLastModifiedDate(jsonContent map[string]interface{}) (*time.Time, bool
 func (s S3Check) isCurrentOperationFinished(pc *PublishCheck) (operationFinished, ignoreCheck bool) {
 	pm := pc.Metric
 	url := pm.endpoint.String() + pm.UUID
-	resp, err := s.httpCaller.doCall(url, pc.username, pc.password)
+	resp, err := s.httpCaller.doCall(url, "", "")
 	if err != nil {
 		warnLogger.Printf("Checking %s. Error calling URL: [%v] : [%v]", loggingContextForCheck(pm.config.Alias, pm.UUID, pm.platform, pm.tid), url, err.Error())
 		return false, false
@@ -195,6 +195,7 @@ func (s S3Check) isCurrentOperationFinished(pc *PublishCheck) (operationFinished
 	defer cleanupResp(resp)
 
 	if resp.StatusCode != 200 {
+		warnLogger.Printf("Checking %s. Error calling URL: [%v] : Response status: [%v]", loggingContextForCheck(pm.config.Alias, pm.UUID, pm.platform, pm.tid), url, resp.Status)
 		return false, false
 	}
 


### PR DESCRIPTION
- No authentication is required for S3 and in fact it fails with a 400
response.
- Log non-200 responses from the S3 check.
- Tweak the testHTTPCaller so that it expects no authorization header
when no credentials are required, and fails if they are presented.