### PR TITLE
'environment' is effectively a reserved work so use 'readEnv'.

### DIFF
--- a/splunkFeeder.go
+++ b/splunkFeeder.go
@@ -21,6 +21,6 @@ func NewSplunkFeeder(logPrefix string) *SplunkFeeder {
 
 // Send logs pm into a file.
 func (sf SplunkFeeder) Send(pm PublishMetric) {
-	sf.MetricLog.Printf("UUID=%v environment=%v transaction_id=%v publishDate=%v publishOk=%v duration=%v endpoint=%v ",
+	sf.MetricLog.Printf("UUID=%v readEnv=%v transaction_id=%v publishDate=%v publishOk=%v duration=%v endpoint=%v ",
 		pm.UUID, pm.platform, pm.tid, pm.publishDate.UnixNano(), pm.publishOK, pm.publishInterval.upperBound, pm.config.Alias)
 }


### PR DESCRIPTION
These messages are parsed by the Splunk logfilter/forwarder (AARGH!!) so
we need a distinct key name.