### PR TITLE
Check the GTG endpoints for each cluster

### DIFF
--- a/gtgCheck.go
+++ b/gtgCheck.go
@@ -1,0 +1,64 @@
+package main
+
+import "net/url"
+
+func runGtgChecks(allEnvironments map[string]Environment, checkedEnvironment Environment) bool {
+	gtg := endpointSpecificChecks["gtg"]
+	check := generateGtgCheckForEnvironment(checkedEnvironment)
+	if check == nil {
+		return false
+	}
+
+	_, ignore := gtg.isCurrentOperationFinished(check)
+	if ignore { // This environment is failing, and could be ignored if other environments are ok.
+		for name, environment := range allEnvironments {
+			if checkedEnvironment.Name == name {
+				continue
+			}
+
+			_, unhealthy := gtg.isCurrentOperationFinished(generateGtgCheckForEnvironment(environment))
+			if !unhealthy { // If the other environment is healthy then we can ignore this failure
+				return ignore
+			}
+		}
+	}
+
+	return false // This environment is healthy, OR no environments are healthy, so do not ignore failure
+}
+
+func generateGtgCheckForEnvironment(env Environment) *PublishCheck {
+	endpoint, err := url.Parse(env.ReadUrl + "/__gtg")
+	if err != nil {
+		errorLogger.Printf("Failed to generate gtg endpoint from read url! url: [%s] - [%v]", env.ReadUrl, err.Error())
+		return nil
+	}
+
+	metric := &PublishMetric {
+		endpoint: *endpoint,
+	}
+
+	return &PublishCheck {
+		username: env.Username,
+		password: env.Password,
+		Metric: *metric,
+	}
+}
+
+func (c GTGCheck) isCurrentOperationFinished(pc *PublishCheck) (operationFinished bool, clusterUnhealthy bool) {
+	infoLogger.Printf("Checking GTG endpoint for cluster [%s]", pc.Metric.endpoint)
+
+	resp, err := c.httpCaller.doCall(pc.Metric.endpoint.String(), pc.username, pc.password)
+
+	if err != nil {
+		warnLogger.Printf("Error calling GTG URL: [%v] for %s : [%v]", pc.Metric.endpoint, pc, err.Error())
+		return true, true
+	}
+
+	if resp.StatusCode != 200 {
+		infoLogger.Printf("GTG Url for delivery cluster [%s] is unhealthy!", pc.Metric.endpoint.String())
+		return true, true
+	}
+
+	infoLogger.Printf("Delivery cluster is healthy. [%s]", pc.Metric.endpoint.String())
+	return true, false
+}

--- a/gtgCheck_test.go
+++ b/gtgCheck_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"testing"
+	"net/http/httptest"
+	"net/http"
+	"github.com/satori/go.uuid"
+	"strings"
+	"encoding/base64"
+	"github.com/stretchr/testify/assert"
+)
+
+
+func getTestGtgEnvironment(t *testing.T, status int) (*httptest.Server, Environment) {
+	uniq := uuid.NewV4().String()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/__gtg", r.URL.Path, "The check should request for the /__gtg endpoint!")
+
+		auth := r.Header.Get("Authorization")
+		b64, _ := base64.StdEncoding.DecodeString(strings.TrimLeft(auth, "Basic "))
+		credentials := string(b64)
+
+		assert.Equal(t, uniq, strings.TrimLeft(credentials, "next:"), "Credentials supplied to GTG endpoint do not much the credentials we expected!")
+
+		w.WriteHeader(status)
+	}))
+
+	infoLogger.Printf("Started test gtg endpoint on [%s] with uuid [%s]", ts.URL, uniq)
+
+	return ts, Environment {
+		Name: uniq,
+		Username: "next",
+		Password: uniq,
+		ReadUrl: ts.URL,
+	}
+}
+
+func TestAllClustersHealthy(t *testing.T){
+	mock1, environment := getTestGtgEnvironment(t, 200)
+	mock2, otherEnvironment := getTestGtgEnvironment(t, 200)
+	mock3, anotherEnvironment := getTestGtgEnvironment(t, 200)
+
+	defer mock1.Close()
+	defer mock2.Close()
+	defer mock3.Close()
+
+	envs := map [string]Environment{
+		environment.Name: environment,
+		otherEnvironment.Name: otherEnvironment,
+		anotherEnvironment.Name: anotherEnvironment,
+	}
+
+	ignore := runGtgChecks(envs, environment)
+
+	assert.False(t, ignore, "All clusters are healthy! This should NOT be ignored!")
+}
+
+func TestRequestedClusterHealthy(t *testing.T){
+	mock1, environment := getTestGtgEnvironment(t, 200)
+	mock2, otherEnvironment := getTestGtgEnvironment(t, 500)
+	mock3, anotherEnvironment := getTestGtgEnvironment(t, 500)
+
+	defer mock1.Close()
+	defer mock2.Close()
+	defer mock3.Close()
+
+	envs := map [string]Environment{
+		environment.Name: environment,
+		otherEnvironment.Name: otherEnvironment,
+		anotherEnvironment.Name: anotherEnvironment,
+	}
+
+	ignore := runGtgChecks(envs, environment)
+
+	assert.False(t, ignore, "The cluster we checked on is healthy! This should NOT be ignored!")
+}
+
+func TestOtherClusterHealthy(t *testing.T){
+	mock1, environment := getTestGtgEnvironment(t, 500)
+	mock2, otherEnvironment := getTestGtgEnvironment(t, 200)
+	mock3, anotherEnvironment := getTestGtgEnvironment(t, 500)
+
+	defer mock1.Close()
+	defer mock2.Close()
+	defer mock3.Close()
+
+	envs := map [string]Environment{
+		environment.Name: environment,
+		otherEnvironment.Name: otherEnvironment,
+		anotherEnvironment.Name: anotherEnvironment,
+	}
+
+	ignore := runGtgChecks(envs, environment)
+
+	assert.True(t, ignore, "At least one other cluster is healthy! This SHOULD be ignored!")
+}
+
+func TestOtherClustersHealthy(t *testing.T){
+	mock1, environment := getTestGtgEnvironment(t, 500)
+	mock2, otherEnvironment := getTestGtgEnvironment(t, 200)
+	mock3, anotherEnvironment := getTestGtgEnvironment(t, 200)
+
+	defer mock1.Close()
+	defer mock2.Close()
+	defer mock3.Close()
+
+	envs := map [string]Environment{
+		environment.Name: environment,
+		otherEnvironment.Name: otherEnvironment,
+		anotherEnvironment.Name: anotherEnvironment,
+	}
+
+	ignore := runGtgChecks(envs, environment)
+
+	assert.True(t, ignore, "At least one other cluster is healthy! This SHOULD be ignored!")
+}
+
+func TestAllClustersUnhealthy(t *testing.T){
+	mock1, environment := getTestGtgEnvironment(t, 500)
+	mock2, otherEnvironment := getTestGtgEnvironment(t, 500)
+	mock3, anotherEnvironment := getTestGtgEnvironment(t, 500)
+
+	defer mock1.Close()
+	defer mock2.Close()
+	defer mock3.Close()
+
+	envs := map [string]Environment{
+		environment.Name: environment,
+		otherEnvironment.Name: otherEnvironment,
+		anotherEnvironment.Name: anotherEnvironment,
+	}
+
+	ignore := runGtgChecks(envs, environment)
+
+	assert.False(t, ignore, "None of our clusters are healthy! This should NOT be ignored!")
+}

--- a/gtgCheck_test.go
+++ b/gtgCheck_test.go
@@ -18,10 +18,10 @@ func getTestGtgEnvironment(t *testing.T, status int) (*httptest.Server, Environm
 		assert.Equal(t, "/__gtg", r.URL.Path, "The check should request for the /__gtg endpoint!")
 
 		auth := r.Header.Get("Authorization")
-		b64, _ := base64.StdEncoding.DecodeString(strings.TrimLeft(auth, "Basic "))
+		b64, _ := base64.StdEncoding.DecodeString(strings.Split(auth, " ")[1])
 		credentials := string(b64)
 
-		assert.Equal(t, uniq, strings.TrimLeft(credentials, "next:"), "Credentials supplied to GTG endpoint do not much the credentials we expected!")
+		assert.Equal(t, uniq, strings.Split(credentials, ":")[1], "Credentials supplied to GTG endpoint do not much the credentials we expected!")
 
 		w.WriteHeader(status)
 	}))

--- a/publishCheck.go
+++ b/publishCheck.go
@@ -47,6 +47,10 @@ type NotificationsCheck struct {
 	httpCaller httpCaller
 }
 
+type GTGCheck struct {
+	httpCaller httpCaller
+}
+
 // httpCaller abstracts http calls
 type httpCaller interface {
 	doCall(url string, username string, password string) (*http.Response, error)
@@ -88,6 +92,7 @@ func init() {
 		"lists":              ContentCheck{hC},
 		"notifications":      NotificationsCheck{hC},
 		"notifications-push": NotificationsCheck{hC},
+		"gtg":		      GTGCheck{hC},
 	}
 }
 


### PR DESCRIPTION
The logic for ignoring checks should conform to the logic described [here](https://docs.google.com/document/d/1WMluokR9HD82Q2r4fgj-zGrcOhft2bOowVdfXowmH0A/edit).

I wrote the tests with **three** mocked delivery clusters, which proves that the logic generally works for 2 or more clusters. (That could be overkill)