### PR TITLE
Measure SLA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ publish-availability-monitor
 .idea/
 /.project
 /config.json
+default.etcd

--- a/app.go
+++ b/app.go
@@ -226,7 +226,8 @@ func handleMessage(msg consumer.Message) {
 		return
 	}
 
-	scheduleChecks(publishedContent, publishDate, tid, publishedContent.IsMarkedDeleted(), &metricContainer, environments)
+	collator := DefaultCollator{environments, InstrumentedScheduler{&metricContainer}, DefaultGTGRunner{}, metricSink, NewSplunkSLAFeeder("[SLAmetrics] ")}
+	collator.MeasureSLA(ContentEvent{publishedContent, publishDate, tid, publishedContent.IsMarkedDeleted()})
 
 	// for images we need to check their corresponding image sets
 	// the image sets don't have messages of their own so we need to create one
@@ -238,7 +239,7 @@ func handleMessage(msg consumer.Message) {
 		}
 		imageSetEomFile := spawnImageSet(eomFile)
 		if imageSetEomFile.UUID != "" {
-			scheduleChecks(imageSetEomFile, publishDate, tid, false, &metricContainer, environments)
+			collator.MeasureSLA(ContentEvent{imageSetEomFile, publishDate, tid, false})
 		}
 	}
 }

--- a/app.go
+++ b/app.go
@@ -226,7 +226,7 @@ func handleMessage(msg consumer.Message) {
 		return
 	}
 
-	collator := DefaultCollator{environments, InstrumentedScheduler{&metricContainer}, DefaultGTGRunner{}, metricSink, NewSplunkSLAFeeder("[SLAmetrics] ")}
+	collator := DefaultCollator{environments, InstrumentedScheduler{&metricContainer}, DefaultGTGRunner{}, metricSink, NewSplunkSLAFeeder("[slaMetrics] ")}
 	collator.MeasureSLA(ContentEvent{publishedContent, publishDate, tid, publishedContent.IsMarkedDeleted()})
 
 	// for images we need to check their corresponding image sets

--- a/gtgCheck.go
+++ b/gtgCheck.go
@@ -1,0 +1,64 @@
+package main
+
+import "net/url"
+
+func runGtgChecks(allEnvironments map[string]Environment, checkedEnvironment Environment) bool {
+	gtg := endpointSpecificChecks["gtg"]
+	check := generateGtgCheckForEnvironment(checkedEnvironment)
+	if check == nil {
+		return false
+	}
+
+	_, ignore := gtg.isCurrentOperationFinished(check)
+	if ignore { // This environment is failing, and could be ignored if other environments are ok.
+		for name, environment := range allEnvironments {
+			if checkedEnvironment.Name == name {
+				continue
+			}
+
+			_, unhealthy := gtg.isCurrentOperationFinished(generateGtgCheckForEnvironment(environment))
+			if !unhealthy { // If the other environment is healthy then we can ignore this failure
+				return ignore
+			}
+		}
+	}
+
+	return false // This environment is healthy, OR no environments are healthy, so do not ignore failure
+}
+
+func generateGtgCheckForEnvironment(env Environment) *PublishCheck {
+	endpoint, err := url.Parse(env.ReadUrl + "/__gtg")
+	if err != nil {
+		errorLogger.Printf("Failed to generate gtg endpoint from read url! url: [%s] - [%v]", env.ReadUrl, err.Error())
+		return nil
+	}
+
+	metric := &PublishMetric {
+		endpoint: *endpoint,
+	}
+
+	return &PublishCheck {
+		username: env.Username,
+		password: env.Password,
+		Metric: *metric,
+	}
+}
+
+func (c GTGCheck) isCurrentOperationFinished(pc *PublishCheck) (operationFinished bool, clusterUnhealthy bool) {
+	infoLogger.Printf("Checking GTG endpoint for cluster [%s]", pc.Metric.endpoint)
+
+	resp, err := c.httpCaller.doCall(pc.Metric.endpoint.String(), pc.username, pc.password)
+
+	if err != nil {
+		warnLogger.Printf("Error calling GTG URL: [%v] for %s : [%v]", pc.Metric.endpoint, pc, err.Error())
+		return true, true
+	}
+
+	if resp.StatusCode != 200 {
+		infoLogger.Printf("GTG Url for delivery cluster [%s] is unhealthy!", pc.Metric.endpoint.String())
+		return true, true
+	}
+
+	infoLogger.Printf("Delivery cluster is healthy. [%s]", pc.Metric.endpoint.String())
+	return true, false
+}

--- a/gtgCheck_test.go
+++ b/gtgCheck_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var gtg = DefaultGTGRunner{}
 
 func getTestGtgEnvironment(t *testing.T, status int) (*httptest.Server, Environment) {
 	uniq := uuid.NewV4().String()
@@ -51,7 +52,7 @@ func TestAllClustersHealthy(t *testing.T){
 		anotherEnvironment.Name: anotherEnvironment,
 	}
 
-	ignore := runGtgChecks(envs, environment)
+	ignore := gtg.RunGtgChecks(envs, environment)
 
 	assert.False(t, ignore, "All clusters are healthy! This should NOT be ignored!")
 }
@@ -71,7 +72,7 @@ func TestRequestedClusterHealthy(t *testing.T){
 		anotherEnvironment.Name: anotherEnvironment,
 	}
 
-	ignore := runGtgChecks(envs, environment)
+	ignore := gtg.RunGtgChecks(envs, environment)
 
 	assert.False(t, ignore, "The cluster we checked on is healthy! This should NOT be ignored!")
 }
@@ -91,7 +92,7 @@ func TestOtherClusterHealthy(t *testing.T){
 		anotherEnvironment.Name: anotherEnvironment,
 	}
 
-	ignore := runGtgChecks(envs, environment)
+	ignore := gtg.RunGtgChecks(envs, environment)
 
 	assert.True(t, ignore, "At least one other cluster is healthy! This SHOULD be ignored!")
 }
@@ -111,7 +112,7 @@ func TestOtherClustersHealthy(t *testing.T){
 		anotherEnvironment.Name: anotherEnvironment,
 	}
 
-	ignore := runGtgChecks(envs, environment)
+	ignore := gtg.RunGtgChecks(envs, environment)
 
 	assert.True(t, ignore, "At least one other cluster is healthy! This SHOULD be ignored!")
 }
@@ -131,7 +132,7 @@ func TestAllClustersUnhealthy(t *testing.T){
 		anotherEnvironment.Name: anotherEnvironment,
 	}
 
-	ignore := runGtgChecks(envs, environment)
+	ignore := gtg.RunGtgChecks(envs, environment)
 
 	assert.False(t, ignore, "None of our clusters are healthy! This should NOT be ignored!")
 }

--- a/gtgCheck_test.go
+++ b/gtgCheck_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"testing"
+	"net/http/httptest"
+	"net/http"
+	"github.com/satori/go.uuid"
+	"strings"
+	"encoding/base64"
+	"github.com/stretchr/testify/assert"
+)
+
+
+func getTestGtgEnvironment(t *testing.T, status int) (*httptest.Server, Environment) {
+	uniq := uuid.NewV4().String()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/__gtg", r.URL.Path, "The check should request for the /__gtg endpoint!")
+
+		auth := r.Header.Get("Authorization")
+		b64, _ := base64.StdEncoding.DecodeString(strings.TrimLeft(auth, "Basic "))
+		credentials := string(b64)
+
+		assert.Equal(t, uniq, strings.TrimLeft(credentials, "next:"), "Credentials supplied to GTG endpoint do not much the credentials we expected!")
+
+		w.WriteHeader(status)
+	}))
+
+	infoLogger.Printf("Started test gtg endpoint on [%s] with uuid [%s]", ts.URL, uniq)
+
+	return ts, Environment {
+		Name: uniq,
+		Username: "next",
+		Password: uniq,
+		ReadUrl: ts.URL,
+	}
+}
+
+func TestAllClustersHealthy(t *testing.T){
+	mock1, environment := getTestGtgEnvironment(t, 200)
+	mock2, otherEnvironment := getTestGtgEnvironment(t, 200)
+	mock3, anotherEnvironment := getTestGtgEnvironment(t, 200)
+
+	defer mock1.Close()
+	defer mock2.Close()
+	defer mock3.Close()
+
+	envs := map [string]Environment{
+		environment.Name: environment,
+		otherEnvironment.Name: otherEnvironment,
+		anotherEnvironment.Name: anotherEnvironment,
+	}
+
+	ignore := runGtgChecks(envs, environment)
+
+	assert.False(t, ignore, "All clusters are healthy! This should NOT be ignored!")
+}
+
+func TestRequestedClusterHealthy(t *testing.T){
+	mock1, environment := getTestGtgEnvironment(t, 200)
+	mock2, otherEnvironment := getTestGtgEnvironment(t, 500)
+	mock3, anotherEnvironment := getTestGtgEnvironment(t, 500)
+
+	defer mock1.Close()
+	defer mock2.Close()
+	defer mock3.Close()
+
+	envs := map [string]Environment{
+		environment.Name: environment,
+		otherEnvironment.Name: otherEnvironment,
+		anotherEnvironment.Name: anotherEnvironment,
+	}
+
+	ignore := runGtgChecks(envs, environment)
+
+	assert.False(t, ignore, "The cluster we checked on is healthy! This should NOT be ignored!")
+}
+
+func TestOtherClusterHealthy(t *testing.T){
+	mock1, environment := getTestGtgEnvironment(t, 500)
+	mock2, otherEnvironment := getTestGtgEnvironment(t, 200)
+	mock3, anotherEnvironment := getTestGtgEnvironment(t, 500)
+
+	defer mock1.Close()
+	defer mock2.Close()
+	defer mock3.Close()
+
+	envs := map [string]Environment{
+		environment.Name: environment,
+		otherEnvironment.Name: otherEnvironment,
+		anotherEnvironment.Name: anotherEnvironment,
+	}
+
+	ignore := runGtgChecks(envs, environment)
+
+	assert.True(t, ignore, "At least one other cluster is healthy! This SHOULD be ignored!")
+}
+
+func TestOtherClustersHealthy(t *testing.T){
+	mock1, environment := getTestGtgEnvironment(t, 500)
+	mock2, otherEnvironment := getTestGtgEnvironment(t, 200)
+	mock3, anotherEnvironment := getTestGtgEnvironment(t, 200)
+
+	defer mock1.Close()
+	defer mock2.Close()
+	defer mock3.Close()
+
+	envs := map [string]Environment{
+		environment.Name: environment,
+		otherEnvironment.Name: otherEnvironment,
+		anotherEnvironment.Name: anotherEnvironment,
+	}
+
+	ignore := runGtgChecks(envs, environment)
+
+	assert.True(t, ignore, "At least one other cluster is healthy! This SHOULD be ignored!")
+}
+
+func TestAllClustersUnhealthy(t *testing.T){
+	mock1, environment := getTestGtgEnvironment(t, 500)
+	mock2, otherEnvironment := getTestGtgEnvironment(t, 500)
+	mock3, anotherEnvironment := getTestGtgEnvironment(t, 500)
+
+	defer mock1.Close()
+	defer mock2.Close()
+	defer mock3.Close()
+
+	envs := map [string]Environment{
+		environment.Name: environment,
+		otherEnvironment.Name: otherEnvironment,
+		anotherEnvironment.Name: anotherEnvironment,
+	}
+
+	ignore := runGtgChecks(envs, environment)
+
+	assert.False(t, ignore, "None of our clusters are healthy! This should NOT be ignored!")
+}

--- a/gtgCheck_test.go
+++ b/gtgCheck_test.go
@@ -18,10 +18,10 @@ func getTestGtgEnvironment(t *testing.T, status int) (*httptest.Server, Environm
 		assert.Equal(t, "/__gtg", r.URL.Path, "The check should request for the /__gtg endpoint!")
 
 		auth := r.Header.Get("Authorization")
-		b64, _ := base64.StdEncoding.DecodeString(strings.TrimLeft(auth, "Basic "))
+		b64, _ := base64.StdEncoding.DecodeString(strings.Split(auth, " ")[1])
 		credentials := string(b64)
 
-		assert.Equal(t, uniq, strings.TrimLeft(credentials, "next:"), "Credentials supplied to GTG endpoint do not much the credentials we expected!")
+		assert.Equal(t, uniq, strings.Split(credentials, ":")[1], "Credentials supplied to GTG endpoint do not much the credentials we expected!")
 
 		w.WriteHeader(status)
 	}))

--- a/measureSLA.go
+++ b/measureSLA.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"time"
+	"github.com/Financial-Times/publish-availability-monitor/content"
+	"sort"
+)
+
+type ContentEvent struct {
+	contentToCheck content.Content
+	publishDate time.Time
+	tid string
+	isMarkedDeleted bool
+}
+
+type Collator interface {
+	MeasureSLA(event ContentEvent)
+}
+
+type DefaultCollator struct {
+	environments map[string]Environment
+	scheduler Scheduler
+	gtg GTGRunner
+	aggregator chan PublishMetric
+	slaFeeder SplunkSLAFeeder
+}
+
+type SLAMetric struct {
+	UUID string
+	tid string
+	publishDate time.Time
+	metPublishSLA bool
+	okEnvironments []string
+}
+
+func (c DefaultCollator) MeasureSLA(event ContentEvent){
+	context := c.scheduler.ScheduleChecks(event, c.environments)
+	go c.CollateResults(event, context)
+}
+
+func (c DefaultCollator) CollateResults(event ContentEvent, context CheckContext){
+	context.waitGroup.Wait()
+
+	mappedResults := make(map[string] bool)
+	for name := range c.environments {
+		mappedResults[name] = true
+	}
+
+	close(context.results) // stop the channel, we don't expect anything else
+
+	for check := range context.results {
+		c.aggregator <- check // output splunk-style logging for the individual checks
+		if !check.publishOK {
+			mappedResults[check.platform] = false
+		}
+	}
+
+	ignoreEnvironment := make(map[string] bool)
+	okEnvironments := []string{}
+
+	for name, healthy := range mappedResults {
+		if !healthy { // At least one check failed for this environment and for this piece of content
+			ignoreEnvironment[name] = c.gtg.RunGtgChecks(c.environments, c.environments[name])
+		} else {
+			okEnvironments = append(okEnvironments, name)
+		}
+	}
+
+	sort.Strings(okEnvironments)
+
+	slaMetric := SLAMetric{UUID: event.contentToCheck.GetUUID(), tid: event.tid, publishDate: event.publishDate, okEnvironments: okEnvironments, metPublishSLA: true}
+
+	if len(ignoreEnvironment) == len(c.environments) { // Number of unhealthy environments == the total number of environments
+		slaMetric.metPublishSLA = false
+		c.slaFeeder.SendPublishSLA(slaMetric)
+		return
+	}
+
+	for _, ignore := range ignoreEnvironment {
+		if !ignore {
+			slaMetric.metPublishSLA = false
+			c.slaFeeder.SendPublishSLA(slaMetric)
+			return
+		}
+	}
+
+	c.slaFeeder.SendPublishSLA(slaMetric)
+}

--- a/measureSLA.go
+++ b/measureSLA.go
@@ -77,7 +77,7 @@ func (c DefaultCollator) CollateResults(event ContentEvent, context CheckContext
 	}
 
 	for _, ignore := range ignoreEnvironment {
-		if !ignore {
+		if !ignore { // If anything should not be ignored, then SLA false.
 			slaMetric.metPublishSLA = false
 			c.slaFeeder.SendPublishSLA(slaMetric)
 			return

--- a/measureSLA_test.go
+++ b/measureSLA_test.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"testing"
+	"github.com/stretchr/testify/mock"
+	"sync"
+	"github.com/Financial-Times/publish-availability-monitor/content"
+	"time"
+)
+
+var matchAny = mock.MatchedBy(func(x interface{}) bool { return true })
+
+type MockGTGRunner struct {
+	mock.Mock
+}
+
+type MockScheduler struct {
+	mock.Mock
+}
+
+type MockSplunkSLAFeeder struct {
+	mock.Mock
+}
+
+func (m MockGTGRunner) RunGtgChecks(all map[string]Environment, env Environment) bool {
+	args := m.Called(all, env)
+	return args.Bool(0)
+}
+
+func (m MockScheduler) ScheduleChecks(event ContentEvent, all map[string]Environment) CheckContext {
+	args := m.Called(event, all)
+	return args.Get(0).(CheckContext)
+}
+
+func (m MockSplunkSLAFeeder) SendPublishSLA(sla SLAMetric) {
+	m.Called(sla)
+}
+
+func setup(sink chan PublishMetric) {
+	splunkFeeder := NewSplunkFeeder("[splunkMetrics] ")
+	aggregator := NewAggregator(sink, []MetricDestination{splunkFeeder})
+	go aggregator.Run()
+}
+
+func publishDate() time.Time {
+	date, _ := time.Parse(time.RFC3339, "2016-10-20T00:00:00Z")
+	return date
+}
+
+func contentEvent() ContentEvent {
+	return ContentEvent{
+		contentToCheck: content.EomFile{UUID: "unique-id"},
+		tid: "tid",
+		publishDate: publishDate(),
+	}
+}
+
+func TestMeasureSLA(t *testing.T){
+	sink := make(chan PublishMetric)
+	defer close(sink)
+	setup(sink)
+
+	gtgRunner := new(MockGTGRunner)
+	scheduler := new(MockScheduler)
+
+	slaFeeder := new (MockSplunkSLAFeeder)
+	slaFeeder.On("SendPublishSLA", SLAMetric{UUID: "unique-id", tid: "tid", publishDate: publishDate(), metPublishSLA: false, okEnvironments: []string{}})
+
+	environments := make(map[string]Environment)
+	testContent := contentEvent()
+
+	gtgRunner.On("RunGtgChecks", matchAny, matchAny).Return(true)
+	scheduler.On("ScheduleChecks", testContent, environments).Return(CheckContext{make(chan PublishMetric), &sync.WaitGroup{}})
+
+	collator := DefaultCollator{environments, scheduler, gtgRunner, sink, slaFeeder}
+	collator.MeasureSLA(testContent)
+
+	scheduler.AssertExpectations(t) // only testing here that the scheduler is called
+}
+
+func TestCollateSuccessfulChecks(t *testing.T){
+	sink := make(chan PublishMetric)
+	defer close(sink)
+	setup(sink)
+
+	channel := make(chan PublishMetric, 2)
+	channel <- PublishMetric{UUID: "unique-id", platform: "test1", publishOK: true}
+	channel <- PublishMetric{UUID: "unique-id", platform: "test2", publishOK: true}
+
+	environments := map[string]Environment {
+		"test1": {Name: "test1"},
+		"test2": {Name: "test2"},
+	}
+
+	wg := &sync.WaitGroup{}
+	context := CheckContext{channel, wg}
+
+	gtgRunner := new(MockGTGRunner)
+
+	slaFeeder := new (MockSplunkSLAFeeder)
+	slaFeeder.On("SendPublishSLA", SLAMetric{UUID: "unique-id", tid: "tid", publishDate: publishDate(), metPublishSLA: true, okEnvironments: []string{"test1", "test2"}})
+
+	collator := DefaultCollator{environments, new(MockScheduler), gtgRunner, sink, slaFeeder}
+	collator.CollateResults(contentEvent(), context)
+
+	gtgRunner.AssertNotCalled(t, "RunGtgChecks", environments, Environment{Name: "test1"})
+	gtgRunner.AssertNotCalled(t, "RunGtgChecks", environments, Environment{Name: "test2"})
+	slaFeeder.AssertExpectations(t)
+}
+
+func TestCollateOneUnsuccessfulCheckAndIgnored(t *testing.T){
+	sink := make(chan PublishMetric)
+	defer close(sink)
+	setup(sink)
+
+	channel := make(chan PublishMetric, 2)
+	channel <- PublishMetric{UUID: "unique-id", platform: "test1", publishOK: false}
+	channel <- PublishMetric{UUID: "unique-id", platform: "test2", publishOK: true}
+
+	environments := map[string]Environment {
+		"test1": {Name: "test1"},
+		"test2": {Name: "test2"},
+	}
+
+	wg := &sync.WaitGroup{}
+	context := CheckContext{channel, wg}
+
+	gtgRunner := new(MockGTGRunner)
+	gtgRunner.On("RunGtgChecks", environments, Environment{Name: "test1"}).Return(true)
+
+	slaFeeder := new (MockSplunkSLAFeeder)
+	slaFeeder.On("SendPublishSLA", SLAMetric{UUID: "unique-id", tid: "tid", publishDate: publishDate(), metPublishSLA: true, okEnvironments: []string{"test2"}})
+
+	collator := DefaultCollator{environments, new(MockScheduler), gtgRunner, sink, slaFeeder}
+	collator.CollateResults(contentEvent(), context)
+
+	gtgRunner.AssertNotCalled(t, "RunGtgChecks", environments, Environment{Name: "test2"})
+	gtgRunner.AssertExpectations(t)
+	slaFeeder.AssertExpectations(t)
+}
+
+func TestCollateBothUnsuccessfulChecksAndIgnored(t *testing.T){
+	sink := make(chan PublishMetric)
+	defer close(sink)
+	setup(sink)
+
+	channel := make(chan PublishMetric, 2)
+	channel <- PublishMetric{UUID: "unique-id", platform: "test1", publishOK: false}
+	channel <- PublishMetric{UUID: "unique-id", platform: "test2", publishOK: false}
+
+	environments := map[string]Environment {
+		"test1": {Name: "test1"},
+		"test2": {Name: "test2"},
+	}
+
+	wg := &sync.WaitGroup{}
+	context := CheckContext{channel, wg}
+
+	gtgRunner := new(MockGTGRunner)
+	gtgRunner.On("RunGtgChecks", environments, Environment{Name: "test1"}).Return(true)
+	gtgRunner.On("RunGtgChecks", environments, Environment{Name: "test2"}).Return(true)
+
+	slaFeeder := new (MockSplunkSLAFeeder)
+	slaFeeder.On("SendPublishSLA", SLAMetric{UUID: "unique-id", tid: "tid", publishDate: publishDate(), metPublishSLA: false, okEnvironments: []string{}}) // SLA should be false!
+
+	collator := DefaultCollator{environments, new(MockScheduler), gtgRunner, sink, slaFeeder}
+	collator.CollateResults(contentEvent(), context)
+
+	gtgRunner.AssertExpectations(t)
+	slaFeeder.AssertExpectations(t)
+}
+
+func TestCollateBothUnsuccessfulChecksAndNotIgnored(t *testing.T){
+	sink := make(chan PublishMetric)
+	defer close(sink)
+	setup(sink)
+
+	channel := make(chan PublishMetric, 2)
+	channel <- PublishMetric{UUID: "unique-id", platform: "test1", publishOK: false}
+	channel <- PublishMetric{UUID: "unique-id", platform: "test2", publishOK: false}
+
+	environments := map[string]Environment {
+		"test1": {Name: "test1"},
+		"test2": {Name: "test2"},
+	}
+
+	wg := &sync.WaitGroup{}
+	context := CheckContext{channel, wg}
+
+	gtgRunner := new(MockGTGRunner)
+	gtgRunner.On("RunGtgChecks", environments, Environment{Name: "test1"}).Return(false)
+	gtgRunner.On("RunGtgChecks", environments, Environment{Name: "test2"}).Return(false)
+
+	slaFeeder := new (MockSplunkSLAFeeder)
+	slaFeeder.On("SendPublishSLA", SLAMetric{UUID: "unique-id", tid: "tid", publishDate: publishDate(), metPublishSLA: false, okEnvironments: []string{}})
+
+	collator := DefaultCollator{environments, new(MockScheduler), gtgRunner, sink, slaFeeder}
+	collator.CollateResults(contentEvent(), context)
+
+	gtgRunner.AssertExpectations(t)
+	slaFeeder.AssertExpectations(t)
+}
+
+func TestCollateBothUnsuccessfulChecksAndOneNotIgnored(t *testing.T){
+	sink := make(chan PublishMetric)
+	defer close(sink)
+	setup(sink)
+
+	channel := make(chan PublishMetric, 2)
+	channel <- PublishMetric{UUID: "unique-id", platform: "test1", publishOK: false}
+	channel <- PublishMetric{UUID: "unique-id", platform: "test2", publishOK: false}
+
+	environments := map[string]Environment {
+		"test1": {Name: "test1"},
+		"test2": {Name: "test2"},
+	}
+
+	wg := &sync.WaitGroup{}
+	context := CheckContext{channel, wg}
+
+	gtgRunner := new(MockGTGRunner)
+	gtgRunner.On("RunGtgChecks", environments, Environment{Name: "test1"}).Return(false)
+	gtgRunner.On("RunGtgChecks", environments, Environment{Name: "test2"}).Return(true)
+
+	slaFeeder := new (MockSplunkSLAFeeder)
+	slaFeeder.On("SendPublishSLA", SLAMetric{UUID: "unique-id", tid: "tid", publishDate: publishDate(), metPublishSLA: false, okEnvironments: []string{}})
+
+	collator := DefaultCollator{environments, new(MockScheduler), gtgRunner, sink, slaFeeder}
+	collator.CollateResults(contentEvent(), context)
+
+	gtgRunner.AssertExpectations(t)
+	slaFeeder.AssertExpectations(t)
+}
+
+func TestCollateOneUnsuccessfulCheckAndNotIgnored(t *testing.T){
+	sink := make(chan PublishMetric)
+	defer close(sink)
+	setup(sink)
+
+	channel := make(chan PublishMetric, 2)
+	channel <- PublishMetric{UUID: "unique-id", platform: "test1", publishOK: false}
+	channel <- PublishMetric{UUID: "unique-id", platform: "test2", publishOK: true}
+
+	environments := map[string]Environment {
+		"test1": {Name: "test1"},
+		"test2": {Name: "test2"},
+	}
+
+	wg := &sync.WaitGroup{}
+	context := CheckContext{channel, wg}
+
+	gtgRunner := new(MockGTGRunner)
+	gtgRunner.On("RunGtgChecks", environments, Environment{Name: "test1"}).Return(false)
+
+	slaFeeder := new (MockSplunkSLAFeeder)
+	slaFeeder.On("SendPublishSLA", SLAMetric{UUID: "unique-id", tid: "tid", publishDate: publishDate(), metPublishSLA: false, okEnvironments: []string{"test2"}}) // SLA should be false!
+
+	collator := DefaultCollator{environments, new(MockScheduler), gtgRunner, sink, slaFeeder}
+	collator.CollateResults(contentEvent(), context)
+
+	gtgRunner.AssertNotCalled(t, "RunGtgChecks", environments, Environment{Name: "test2"})
+	gtgRunner.AssertExpectations(t)
+	slaFeeder.AssertExpectations(t)
+}

--- a/publishCheck.go
+++ b/publishCheck.go
@@ -47,6 +47,10 @@ type NotificationsCheck struct {
 	httpCaller httpCaller
 }
 
+type GTGCheck struct {
+	httpCaller httpCaller
+}
+
 // httpCaller abstracts http calls
 type httpCaller interface {
 	doCall(url string, username string, password string) (*http.Response, error)
@@ -88,6 +92,7 @@ func init() {
 		"lists":              ContentCheck{hC},
 		"notifications":      NotificationsCheck{hC},
 		"notifications-push": NotificationsCheck{hC},
+		"gtg":		      GTGCheck{hC},
 	}
 }
 

--- a/publishCheck.go
+++ b/publishCheck.go
@@ -20,7 +20,6 @@ type PublishCheck struct {
 	password      string
 	Threshold     int
 	CheckInterval int
-	ResultSink    chan PublishMetric
 }
 
 // EndpointSpecificCheck is the interface which determines the state of the operation we are currently checking.
@@ -75,8 +74,8 @@ func (c defaultHTTPCaller) doCall(url string, username string, password string) 
 
 // NewPublishCheck returns a PublishCheck ready to perform a check for pm.UUID, at the
 // pm.endpoint.
-func NewPublishCheck(pm PublishMetric, username string, password string, t int, ci int, rs chan PublishMetric) *PublishCheck {
-	return &PublishCheck{pm, username, password, t, ci, rs}
+func NewPublishCheck(pm PublishMetric, username string, password string, t int, ci int) *PublishCheck {
+	return &PublishCheck{pm, username, password, t, ci}
 }
 
 var endpointSpecificChecks map[string]EndpointSpecificCheck

--- a/publishCheck_notificationsCheck_test.go
+++ b/publishCheck_notificationsCheck_test.go
@@ -21,7 +21,7 @@ func TestCheckBatchOfNotifications_ResponseBatchOfNotificationsIsEmpty_NotFinish
 	notificationsCheck := &NotificationsCheck{
 		mockHTTPCaller(buildResponse(200, testResponse)),
 	}
-	pc := NewPublishCheck(newPublishMetricBuilder().build(), "", "", 0, 0, nil)
+	pc := NewPublishCheck(newPublishMetricBuilder().build(), "", "", 0, 0)
 	if result := notificationsCheck.checkBatchOfNotifications("dummy-url", pc); result.operationFinished {
 		t.Error("Expected failure")
 	}
@@ -49,7 +49,7 @@ func TestCheckBatchOfNotifications_ResponseDoesNotContainUUID_NotFinished(t *tes
 	notificationsCheck := &NotificationsCheck{
 		mockHTTPCaller(buildResponse(200, testResponse)),
 	}
-	pc := NewPublishCheck(newPublishMetricBuilder().withUUID("1cb14245-5185-4ed5-9188-4d2a86085598").withTID("tid_0123wxyz").build(), "", "", 0, 0, nil)
+	pc := NewPublishCheck(newPublishMetricBuilder().withUUID("1cb14245-5185-4ed5-9188-4d2a86085598").withTID("tid_0123wxyz").build(), "", "", 0, 0)
 	if result := notificationsCheck.checkBatchOfNotifications("dummy-url", pc); result.operationFinished {
 		t.Error("Expected failure")
 	}
@@ -79,7 +79,7 @@ func TestCheckBatchOfNotifications_ResponseDoesContainUUIDLastModifiedFieldIsUnp
 	notificationsCheck := &NotificationsCheck{
 		mockHTTPCaller(buildResponse(200, testResponse)),
 	}
-	pc := NewPublishCheck(newPublishMetricBuilder().withUUID(currentUUID).withTID("tid_0123wxyz").build(), "", "", 0, 0, nil)
+	pc := NewPublishCheck(newPublishMetricBuilder().withUUID(currentUUID).withTID("tid_0123wxyz").build(), "", "", 0, 0)
 	if result := notificationsCheck.checkBatchOfNotifications("dummy-url", pc); result.operationFinished {
 		t.Error("Expected failure")
 	}
@@ -110,7 +110,7 @@ func TestCheckBatchOfNotifications_ResponseDoesContainUUIDLastModifiedFieldIsUnp
 	notificationsCheck := &NotificationsCheck{
 		mockHTTPCaller(buildResponse(200, testResponse)),
 	}
-	pc := NewPublishCheck(newPublishMetricBuilder().withUUID(currentUUID).withTID(currentTID).build(), "", "", 0, 0, nil)
+	pc := NewPublishCheck(newPublishMetricBuilder().withUUID(currentUUID).withTID(currentTID).build(), "", "", 0, 0)
 	if result := notificationsCheck.checkBatchOfNotifications("dummy-url", pc); !result.operationFinished {
 		t.Error("Expected success")
 	}
@@ -144,7 +144,7 @@ func TestCheckBatchOfNotifications_ResponseDoesContainUUIDLastModifiedFieldIsAft
 	notificationsCheck := &NotificationsCheck{
 		mockHTTPCaller(buildResponse(200, testResponse)),
 	}
-	pc := NewPublishCheck(newPublishMetricBuilder().withUUID(currentUUID).withPublishDate(currentPublishedDate).build(), "", "", 0, 0, nil)
+	pc := NewPublishCheck(newPublishMetricBuilder().withUUID(currentUUID).withPublishDate(currentPublishedDate).build(), "", "", 0, 0)
 	if result := notificationsCheck.checkBatchOfNotifications("dummy-url", pc); !result.ignoreCheck {
 		t.Error("Expected ignoreCheck to be [true].")
 	}
@@ -178,7 +178,7 @@ func TestCheckBatchOfNotifications_ResponseDoesContainUUIDLastModifiedFieldEqual
 	notificationsCheck := &NotificationsCheck{
 		mockHTTPCaller(buildResponse(200, testResponse)),
 	}
-	pc := NewPublishCheck(newPublishMetricBuilder().withUUID(currentUUID).withPublishDate(currentPublishedDate).build(), "", "", 0, 0, nil)
+	pc := NewPublishCheck(newPublishMetricBuilder().withUUID(currentUUID).withPublishDate(currentPublishedDate).build(), "", "", 0, 0)
 	if result := notificationsCheck.checkBatchOfNotifications("dummy-url", pc); !result.operationFinished {
 		t.Error("Expected success.")
 	}
@@ -212,7 +212,7 @@ func TestCheckBatchOfNotifications_ResponseDoesContainUUIDLastModifiedFieldBefor
 	notificationsCheck := &NotificationsCheck{
 		mockHTTPCaller(buildResponse(200, testResponse)),
 	}
-	pc := NewPublishCheck(newPublishMetricBuilder().withUUID(currentUUID).withPublishDate(currentPublishedDate).build(), "", "", 0, 0, nil)
+	pc := NewPublishCheck(newPublishMetricBuilder().withUUID(currentUUID).withPublishDate(currentPublishedDate).build(), "", "", 0, 0)
 	if result := notificationsCheck.checkBatchOfNotifications("dummy-url", pc); result.operationFinished {
 		t.Error("Expected failure.")
 	}
@@ -241,7 +241,7 @@ func TestCheckBatchOfNotifications_ResponseIsNotEmptyDoesNotContainUUID_NextNoti
 	notificationsCheck := &NotificationsCheck{
 		mockHTTPCaller(buildResponse(200, testResponse)),
 	}
-	pc := NewPublishCheck(newPublishMetricBuilder().withUUID(currentUUID).build(), "", "", 0, 0, nil)
+	pc := NewPublishCheck(newPublishMetricBuilder().withUUID(currentUUID).build(), "", "", 0, 0)
 	if result := notificationsCheck.checkBatchOfNotifications("dummy-url", pc); result.nextNotificationsURL != nextNotificationsURL {
 		t.Error("Expected success.")
 	}
@@ -261,7 +261,7 @@ func TestCheckBatchOfNotifications_ResponseBatchOfNotificationsIsEmpty_NextNotif
 	notificationsCheck := &NotificationsCheck{
 		mockHTTPCaller(buildResponse(200, testResponse)),
 	}
-	pc := NewPublishCheck(newPublishMetricBuilder().build(), "", "", 0, 0, nil)
+	pc := NewPublishCheck(newPublishMetricBuilder().build(), "", "", 0, 0)
 	if result := notificationsCheck.checkBatchOfNotifications("dummy-url", pc); result.nextNotificationsURL != "" {
 		t.Error("Expected empty string.")
 	}
@@ -292,7 +292,7 @@ func TestIsCurrentOperationFinished_FirstBatchOfNotificationsContainsUUIDAndTID_
 		mockHTTPCaller(buildResponse(200, testResponse)),
 	}
 
-	pc := NewPublishCheck(newPublishMetricBuilder().withTID(testTID).build(), "", "", 0, 0, nil)
+	pc := NewPublishCheck(newPublishMetricBuilder().withTID(testTID).build(), "", "", 0, 0)
 	if finished, _ := notificationsCheck.isCurrentOperationFinished(pc); !finished {
 		t.Error("Expected success")
 	}
@@ -330,7 +330,7 @@ func TestIsCurrentOperationFinished_FirstBatchOfNotificationsDoesNotContainUUIDS
 	notificationsCheck := &NotificationsCheck{
 		mockHTTPCaller(buildResponse(200, testResponse1), buildResponse(200, testResponse2)),
 	}
-	pc := NewPublishCheck(newPublishMetricBuilder().withTID("tid_0123wxyZ").withUUID(currentUUID).build(), "", "", 0, 0, nil)
+	pc := NewPublishCheck(newPublishMetricBuilder().withTID("tid_0123wxyZ").withUUID(currentUUID).build(), "", "", 0, 0)
 	if finished, _ := notificationsCheck.isCurrentOperationFinished(pc); finished {
 		t.Error("Expected failure")
 	}
@@ -378,7 +378,7 @@ func TestIsCurrentOperationFinished_FirstBatchOfNotificationsDoesNotContainUUIDB
 		mockHTTPCaller(buildResponse(200, testResponse1), buildResponse(200, testResponse2)),
 	}
 
-	pc := NewPublishCheck(newPublishMetricBuilder().withTID(currentTID).withUUID(currentUUID).build(), "", "", 0, 0, nil)
+	pc := NewPublishCheck(newPublishMetricBuilder().withTID(currentTID).withUUID(currentUUID).build(), "", "", 0, 0)
 	if finished, _ := notificationsCheck.isCurrentOperationFinished(pc); !finished {
 		t.Error("Expected success")
 	}
@@ -421,7 +421,7 @@ func TestAdjustNextNotificationsURL_CurrentHostAndPortDiffers_Success(t *testing
 func TestShouldSkipCheck_ContentIsNotMarkedAsDeleted_CheckNotSkipped(t *testing.T) {
 	pm := newPublishMetricBuilder().withMarkedDeleted(false).build()
 	notificationsCheck := NotificationsCheck{}
-	pc := NewPublishCheck(pm, "", "", 0, 0, nil)
+	pc := NewPublishCheck(pm, "", "", 0, 0)
 
 	if notificationsCheck.shouldSkipCheck(pc) {
 		t.Errorf("Expected failure")
@@ -430,7 +430,7 @@ func TestShouldSkipCheck_ContentIsNotMarkedAsDeleted_CheckNotSkipped(t *testing.
 
 func TestShouldSkipCheck_ContentIsMarkedAsDeletedPreviousNotificationsExist_CheckNotSkipped(t *testing.T) {
 	pm := newPublishMetricBuilder().withMarkedDeleted(true).withEndpoint("http://notifications-endpoint:8080/content/notifications").build()
-	pc := NewPublishCheck(pm, "", "", 0, 0, nil)
+	pc := NewPublishCheck(pm, "", "", 0, 0)
 	notificationsCheck := NotificationsCheck{
 		mockHTTPCaller(buildResponse(200, `[{"id": "foobar", "lastModified" : "foobaz", "publishReference" : "unitTestRef" }]`)),
 	}
@@ -441,7 +441,7 @@ func TestShouldSkipCheck_ContentIsMarkedAsDeletedPreviousNotificationsExist_Chec
 
 func TestShouldSkipCheck_ContentIsMarkedAsDeletedPreviousNotificationsDoesNotExist_CheckSkipped(t *testing.T) {
 	pm := newPublishMetricBuilder().withMarkedDeleted(true).withEndpoint("http://notifications-endpoint:8080/content/notifications").build()
-	pc := NewPublishCheck(pm, "", "", 0, 0, nil)
+	pc := NewPublishCheck(pm, "", "", 0, 0)
 	notificationsCheck := NotificationsCheck{
 		mockHTTPCaller(buildResponse(200, `[]`)),
 	}
@@ -483,7 +483,7 @@ func TestCheckNotificationItems_ShouldNotFinishOpIfNotFound(t *testing.T) {
 		tid:             "tid_testtest99",
 		isMarkedDeleted: false,
 	}
-	pc := NewPublishCheck(pm, "", "", 0, 0, nil)
+	pc := NewPublishCheck(pm, "", "", 0, 0)
 	var defaultResult = notificationCheckResult{operationFinished: false, ignoreCheck: false, nextNotificationsURL: ""}
 	actual := checkNotificationItems(notifications, pc, defaultResult)
 

--- a/publishCheck_test.go
+++ b/publishCheck_test.go
@@ -14,7 +14,7 @@ func TestIsCurrentOperationFinished_S3Check_Finished(t *testing.T) {
 	s3Check := &S3Check{
 		mockHTTPCaller(buildResponse(200, "imagebytes")),
 	}
-	if finished, _ := s3Check.isCurrentOperationFinished(NewPublishCheck(PublishMetric{}, "", "", 0, 0, nil)); !finished {
+	if finished, _ := s3Check.isCurrentOperationFinished(NewPublishCheck(PublishMetric{}, "", "", 0, 0)); !finished {
 		t.Errorf("Expected: true. Actual: false")
 	}
 }
@@ -26,7 +26,7 @@ func TestIsCurrentOperationFinished_S3Check_DoesNotSendAuthentication(t *testing
 	}
 
 	pm := newPublishMetricBuilder().withTID(currentTid).build()
-	pc := NewPublishCheck(pm, "jdoe", "frodo", 0, 0, nil)
+	pc := NewPublishCheck(pm, "jdoe", "frodo", 0, 0)
 	if finished, _ := s3Check.isCurrentOperationFinished(pc); !finished {
 		t.Error("Expected success.")
 	}
@@ -36,7 +36,7 @@ func TestIsCurrentOperationFinished_S3Check_Empty(t *testing.T) {
 	s3Check := &S3Check{
 		mockHTTPCaller(buildResponse(200, "")),
 	}
-	if finished, _ := s3Check.isCurrentOperationFinished(NewPublishCheck(PublishMetric{}, "", "", 0, 0, nil)); finished {
+	if finished, _ := s3Check.isCurrentOperationFinished(NewPublishCheck(PublishMetric{}, "", "", 0, 0)); finished {
 		t.Errorf("Expected: false. Actual: true")
 	}
 }
@@ -45,7 +45,7 @@ func TestIsCurrentOperationFinished_S3Check_NotFinished(t *testing.T) {
 	s3Check := &S3Check{
 		mockHTTPCaller(buildResponse(404, "")),
 	}
-	if finished, _ := s3Check.isCurrentOperationFinished(NewPublishCheck(PublishMetric{}, "", "", 0, 0, nil)); finished {
+	if finished, _ := s3Check.isCurrentOperationFinished(NewPublishCheck(PublishMetric{}, "", "", 0, 0)); finished {
 		t.Errorf("Expected: false. Actual: True")
 	}
 }
@@ -56,7 +56,7 @@ func TestIsCurrentOperationFinished_ContentCheck_InvalidContent(t *testing.T) {
 		mockHTTPCaller(buildResponse(200, testResponse)),
 	}
 
-	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(PublishMetric{}, "", "", 0, 0, nil)); finished {
+	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(PublishMetric{}, "", "", 0, 0)); finished {
 		t.Errorf("Expected error.")
 	}
 }
@@ -69,7 +69,7 @@ func TestIsCurrentOperationFinished_ContentCheck_Finished(t *testing.T) {
 	}
 
 	pm := newPublishMetricBuilder().withTID(currentTid).build()
-	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0, nil)); !finished {
+	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0)); !finished {
 		t.Error("Expected success.")
 	}
 }
@@ -84,7 +84,7 @@ func TestIsCurrentOperationFinished_ContentCheck_WithAuthentication(t *testing.T
 	}
 
 	pm := newPublishMetricBuilder().withTID(currentTid).build()
-	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, username, password, 0, 0, nil)); !finished {
+	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, username, password, 0, 0)); !finished {
 		t.Error("Expected success.")
 	}
 }
@@ -97,7 +97,7 @@ func TestIsCurrentOperationFinished_ContentCheck_NotFinished(t *testing.T) {
 	}
 
 	pm := newPublishMetricBuilder().withTID(currentTid).build()
-	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0, nil)); finished {
+	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0)); finished {
 		t.Error("Expected failure.")
 	}
 }
@@ -110,7 +110,7 @@ func TestIsCurrentOperationFinished_ContentCheck_MarkedDeleted_Finished(t *testi
 	}
 
 	pm := newPublishMetricBuilder().withTID(currentTid).withMarkedDeleted(true).build()
-	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0, nil)); !finished {
+	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0)); !finished {
 		t.Error("Expected success.")
 	}
 }
@@ -123,7 +123,7 @@ func TestIsCurrentOperationFinished_ContentCheck_MarkedDeleted_NotFinished(t *te
 	}
 
 	pm := newPublishMetricBuilder().withTID(currentTid).withMarkedDeleted(true).build()
-	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0, nil)); finished {
+	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0)); finished {
 		t.Error("Expected failure.")
 	}
 }
@@ -141,7 +141,7 @@ func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsAfterCurrentP
 	}
 
 	pm := newPublishMetricBuilder().withTID(currentTid).withPublishDate(publishDate).build()
-	if _, ignoreCheck := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0, nil)); !ignoreCheck {
+	if _, ignoreCheck := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0)); !ignoreCheck {
 		t.Error("Expected ignoreCheck to be true")
 	}
 }
@@ -161,7 +161,7 @@ func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsBeforeCurrent
 	}
 
 	pm := newPublishMetricBuilder().withTID(currentTid).withPublishDate(publishDate).build()
-	if _, ignoreCheck := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0, nil)); ignoreCheck {
+	if _, ignoreCheck := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0)); ignoreCheck {
 		t.Error("Expected ignoreCheck to be false")
 	}
 }
@@ -179,7 +179,7 @@ func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsBeforeCurrent
 	}
 
 	pm := newPublishMetricBuilder().withTID(currentTid).withPublishDate(publishDate).build()
-	if _, ignoreCheck := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0, nil)); ignoreCheck {
+	if _, ignoreCheck := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0)); ignoreCheck {
 		t.Error("Expected ignoreCheck to be false.")
 	}
 }
@@ -197,7 +197,7 @@ func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsBeforeCurrent
 	}
 
 	pm := newPublishMetricBuilder().withTID(currentTid).withPublishDate(publishDate).build()
-	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0, nil)); finished {
+	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0)); finished {
 		t.Error("Expected failure.")
 	}
 }
@@ -216,7 +216,7 @@ func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateEqualsCurrentPu
 	}
 
 	pm := newPublishMetricBuilder().withTID(currentTid).withPublishDate(publishDate).build()
-	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0, nil)); !finished {
+	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0)); !finished {
 		t.Error("Expected success.")
 	}
 }
@@ -235,7 +235,7 @@ func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsNullCurrentTI
 	}
 
 	pm := newPublishMetricBuilder().withTID(currentTid).withPublishDate(publishDate).build()
-	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0, nil)); !finished {
+	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0)); !finished {
 		t.Error("Expected success.")
 	}
 }
@@ -254,7 +254,7 @@ func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsEmptyStringCu
 	}
 
 	pm := newPublishMetricBuilder().withTID(currentTid).withPublishDate(publishDate).build()
-	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0, nil)); !finished {
+	if finished, _ := contentCheck.isCurrentOperationFinished(NewPublishCheck(pm, "", "", 0, 0)); !finished {
 		t.Error("Expected success.")
 	}
 }

--- a/splunkFeeder.go
+++ b/splunkFeeder.go
@@ -24,3 +24,20 @@ func (sf SplunkFeeder) Send(pm PublishMetric) {
 	sf.MetricLog.Printf("UUID=%v readEnv=%v transaction_id=%v publishDate=%v publishOk=%v duration=%v endpoint=%v ",
 		pm.UUID, pm.platform, pm.tid, pm.publishDate.UnixNano(), pm.publishOK, pm.publishInterval.upperBound, pm.config.Alias)
 }
+
+type SplunkSLAFeeder interface {
+	SendPublishSLA(sla SLAMetric)
+}
+
+type DefaultSplunkSLAFeeder struct {
+	MetricLog *log.Logger
+}
+
+func NewSplunkSLAFeeder(logPrefix string) SplunkSLAFeeder {
+	logger := log.New(os.Stdout, logPrefix, log.Ldate|log.Ltime|log.Lmicroseconds|log.LUTC)
+	return DefaultSplunkSLAFeeder{logger}
+}
+
+func (sf DefaultSplunkSLAFeeder) SendPublishSLA(sm SLAMetric) {
+	sf.MetricLog.Printf("UUID=%v metPublishSLA=%v okEnvironments=%v transaction_id=%v publishDate=%v", sm.UUID, sm.metPublishSLA, sm.okEnvironments, sm.tid, sm.publishDate.UnixNano())
+}


### PR DESCRIPTION
Measure and report (via logging) on PAM SLA failures as laid out by [this document](https://docs.google.com/document/d/1DaciAe9Gra_EnqtKNQw7mgvuQyVIMq2K5vRKVmWk3Yc/edit#).

At a high level; PAM now:
- Schedules checks via a single Collator
- The collator will wait for checks to pass/fail
- Report failed checks (publishOk=false) as normal.
- Report an overall failed SLA based on the results of all the checks against all the environments.
