### PR TITLE
S3 read urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The monitor can check publication across several different environments, provide
 
 `/ft/config/monitoring/read-urls`: a comma-separated list of _name_`:`_value_ pairs, mapping from environment name to base read URL, e.g. `env1:http://foo.example.org,env2:http://bar.example.org`
 
-`/ft/config/monitoring/s3-urls`: a comma-separated list of _name_`:`_value_ pairs, mapping from environment name to base S3 URL, e.g. `env1:http://foo.example.org,env2:http://bar.example.org`
+`/ft/config/monitoring/s3-image-bucket-urls`: a comma-separated list of _name_`:`_value_ pairs, mapping from environment name to base S3 URL, e.g. `env1:http://s3bucket1.org,env2:http://s3bucket2.org`
 
 `/ft/_credentials/publish-read/read-credentials`: a comma-separated list of _name_`:`_username_`:`_password_ tuples, mapping from environment name to basic HTTP credentials, e.g. `env1:scott:tiger,env2:friend:frodo`. The _name_ must match a name in the read-urls key; if an environment does not require authentication, credentials should be omitted.
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ __Note that deployment to FTP2 is no longer supported.__
 The monitor can check publication across several different environments, provided each environment can be accessed by a single host URL. The monitor reads from `etcd` and watches for changes in the following paths:
 
 `/ft/config/monitoring/read-urls`: a comma-separated list of _name_`:`_value_ pairs, mapping from environment name to base read URL, e.g. `env1:http://foo.example.org,env2:http://bar.example.org`
+
 `/ft/config/monitoring/s3-urls`: a comma-separated list of _name_`:`_value_ pairs, mapping from environment name to base S3 URL, e.g. `env1:http://foo.example.org,env2:http://bar.example.org`
 
 `/ft/_credentials/publish-read/read-credentials`: a comma-separated list of _name_`:`_username_`:`_password_ tuples, mapping from environment name to basic HTTP credentials, e.g. `env1:scott:tiger,env2:friend:frodo`. The _name_ must match a name in the read-urls key; if an environment does not require authentication, credentials should be omitted.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ __Note that deployment to FTP2 is no longer supported.__
 The monitor can check publication across several different environments, provided each environment can be accessed by a single host URL. The monitor reads from `etcd` and watches for changes in the following paths:
 
 `/ft/config/monitoring/read-urls`: a comma-separated list of _name_`:`_value_ pairs, mapping from environment name to base read URL, e.g. `env1:http://foo.example.org,env2:http://bar.example.org`
+`/ft/config/monitoring/s3-urls`: a comma-separated list of _name_`:`_value_ pairs, mapping from environment name to base S3 URL, e.g. `env1:http://foo.example.org,env2:http://bar.example.org`
 
 `/ft/_credentials/publish-read/read-credentials`: a comma-separated list of _name_`:`_username_`:`_password_ tuples, mapping from environment name to basic HTTP credentials, e.g. `env1:scott:tiger,env2:friend:frodo`. The _name_ must match a name in the read-urls key; if an environment does not require authentication, credentials should be omitted.
 

--- a/app.go
+++ b/app.go
@@ -74,6 +74,7 @@ type HealthConfig struct {
 type Environment struct {
 	Name     string
 	ReadUrl  string
+	S3Url    string
 	Username string
 	Password string
 }
@@ -91,7 +92,8 @@ var warnLogger *log.Logger
 var errorLogger *log.Logger
 var configFileName = flag.String("config", "", "Path to configuration file")
 var etcdPeers = flag.String("etcd-peers", "http://localhost:2379", "Comma-separated list of addresses of etcd endpoints to connect to")
-var etcdEnvKey = flag.String("etcd-env-key", "/ft/config/monitoring/read-urls", "etcd key that lists the read environment URLs")
+var etcdReadEnvKey = flag.String("etcd-read-env-key", "/ft/config/monitoring/read-urls", "etcd key that lists the read environment URLs")
+var etcdS3EnvKey = flag.String("etcd-s3-env-key", "/ft/config/monitoring/s3-urls", "etcd key that lists the S3 environment URLs")
 var etcdCredKey = flag.String("etcd-cred-key", "/ft/_credentials/publish-read/read-credentials", "etcd key that lists the read environment credentials")
 var etcdValidatorCredKey = flag.String("etcd-validator-cred-key", "/ft/_credentials/publish-read/validator-credentials", "etcd key that specifies the validator credentials")
 
@@ -113,7 +115,7 @@ func main() {
 		return
 	}
 
-	go DiscoverEnvironmentsAndValidators(etcdPeers, etcdEnvKey, etcdCredKey, etcdValidatorCredKey, environments)
+	go DiscoverEnvironmentsAndValidators(etcdPeers, etcdReadEnvKey, etcdCredKey, etcdS3EnvKey, etcdValidatorCredKey, environments)
 
 	metricContainer = publishHistory{sync.RWMutex{}, make([]PublishMetric, 0)}
 

--- a/app.go
+++ b/app.go
@@ -93,7 +93,7 @@ var errorLogger *log.Logger
 var configFileName = flag.String("config", "", "Path to configuration file")
 var etcdPeers = flag.String("etcd-peers", "http://localhost:2379", "Comma-separated list of addresses of etcd endpoints to connect to")
 var etcdReadEnvKey = flag.String("etcd-read-env-key", "/ft/config/monitoring/read-urls", "etcd key that lists the read environment URLs")
-var etcdS3EnvKey = flag.String("etcd-s3-env-key", "/ft/config/monitoring/s3-urls", "etcd key that lists the S3 environment URLs")
+var etcdS3EnvKey = flag.String("etcd-s3-env-key", "/ft/config/monitoring/s3-image-bucket-urls", "etcd key that lists the S3 image bucket URLs")
 var etcdCredKey = flag.String("etcd-cred-key", "/ft/_credentials/publish-read/read-credentials", "etcd key that lists the read environment credentials")
 var etcdValidatorCredKey = flag.String("etcd-validator-cred-key", "/ft/_credentials/publish-read/validator-credentials", "etcd key that specifies the validator credentials")
 

--- a/app_test.go
+++ b/app_test.go
@@ -38,8 +38,8 @@ func TestIsIgnorableMessage_syntheticMessage(t *testing.T) {
 }
 
 func TestGetCredentials(t *testing.T) {
-	environments["env1"] = Environment{"env1", "http://env1.example.org", "user1", "pass1"}
-	environments["env2"] = Environment{"env2", "http://env2.example.org", "user2", "pass2"}
+	environments["env1"] = Environment{"env1", "http://env1.example.org", "http://s3.example.org", "user1", "pass1"}
+	environments["env2"] = Environment{"env2", "http://env2.example.org", "http://s3.example.org", "user2", "pass2"}
 
 	username, password := getCredentials("http://env2.example.org/__some-service")
 	if username != "user2" || password != "pass2" {
@@ -48,8 +48,8 @@ func TestGetCredentials(t *testing.T) {
 }
 
 func TestGetCredentials_Unauthenticated(t *testing.T) {
-	environments["env1"] = Environment{"env1", "http://env1.example.org", "user1", "pass1"}
-	environments["env2"] = Environment{"env2", "http://env2.example.org", "user2", "pass2"}
+	environments["env1"] = Environment{"env1", "http://env1.example.org", "http://s3.example.org", "user1", "pass1"}
+	environments["env2"] = Environment{"env2", "http://env2.example.org", "http://s3.example.org", "user2", "pass2"}
 
 	username, password := getCredentials("http://env3.example.org/__some-service")
 	if username != "" || password != "" {

--- a/content/wordPressContent_test.go
+++ b/content/wordPressContent_test.go
@@ -30,9 +30,8 @@ var wordpressContentWithInvalidBlogDomain = WordPressMessage{
 	Status: "ok", Post: Post{"post", "58bdb656-8f7a-4a8c-b2b9-f9722824b318", "http://ftalphaville-wp.ft.com/?pid=1234"},
 }
 
-
 func TestIsValidBlogDomain_True(t *testing.T) {
-	if!wordpressContentWithValidBlogDomain.IsValid("", "", "") {
+	if !wordpressContentWithValidBlogDomain.IsValid("", "", "") {
 		t.Error("Expected True")
 	}
 }

--- a/environments.go
+++ b/environments.go
@@ -132,7 +132,6 @@ func parseEnvironmentsIntoMap(etcdReadEnv string, etcdCred string, etcdS3Env str
 				break
 			}
 		}
-
 		if s3Url == "" {
 			infoLogger.Printf("No S3 url supplied for access to environment %v", name)
 		}

--- a/environments_test.go
+++ b/environments_test.go
@@ -8,17 +8,19 @@ import (
 
 func TestParseEtcdValues(t *testing.T) {
 	environments := make(map[string]Environment)
-	parseEnvironmentsIntoMap("t1:https://t1.example.org,t2:https://t2.example.com", "t1:user1:pass1,t2:user2:pass2", environments)
+	parseEnvironmentsIntoMap("t1:https://t1.example.org,t2:https://t2.example.com", "t1:user1:pass1,t2:user2:pass2", "t1:https://s1.example.org,t2:https://s2.example.org", environments)
 
 	t1 := environments["t1"]
 	assert.Equal(t, "t1", t1.Name, "environment name")
 	assert.Equal(t, "https://t1.example.org", t1.ReadUrl, "environment read url")
+	assert.Equal(t, "https://s1.example.org", t1.S3Url, "environment s3 url")
 	assert.Equal(t, "user1", t1.Username, "environment username")
 	assert.Equal(t, "pass1", t1.Password, "environment password")
 
 	t2 := environments["t2"]
 	assert.Equal(t, "t2", t2.Name, "environment name")
 	assert.Equal(t, "https://t2.example.com", t2.ReadUrl, "environment read url")
+	assert.Equal(t, "https://s2.example.org", t2.S3Url, "environment s3 url")
 	assert.Equal(t, "user2", t2.Username, "environment username")
 	assert.Equal(t, "pass2", t2.Password, "environment password")
 
@@ -27,17 +29,19 @@ func TestParseEtcdValues(t *testing.T) {
 
 func TestParseEtcdUnauthValues(t *testing.T) {
 	environments := make(map[string]Environment)
-	parseEnvironmentsIntoMap("t1:https://t1.example.org,t2:https://t2.example.com", "t2:user2:pass2", environments)
+	parseEnvironmentsIntoMap("t1:https://t1.example.org,t2:https://t2.example.com", "t2:user2:pass2", "t1:https://s1.example.org,t2:https://s2.example.org", environments)
 
 	t1 := environments["t1"]
 	assert.Equal(t, "t1", t1.Name, "environment name")
 	assert.Equal(t, "https://t1.example.org", t1.ReadUrl, "environment read url")
+	assert.Equal(t, "https://s1.example.org", t1.S3Url, "environment s3 url")
 	assert.Equal(t, "", t1.Username, "environment username")
 	assert.Equal(t, "", t1.Password, "environment password")
 
 	t2 := environments["t2"]
 	assert.Equal(t, "t2", t2.Name, "environment name")
 	assert.Equal(t, "https://t2.example.com", t2.ReadUrl, "environment read url")
+	assert.Equal(t, "https://s2.example.org", t2.S3Url, "environment s3 url")
 	assert.Equal(t, "user2", t2.Username, "environment username")
 	assert.Equal(t, "pass2", t2.Password, "environment password")
 
@@ -46,7 +50,7 @@ func TestParseEtcdUnauthValues(t *testing.T) {
 
 func TestParseEmptyEtcdValues(t *testing.T) {
 	environments := make(map[string]Environment)
-	parseEnvironmentsIntoMap("", "", environments)
+	parseEnvironmentsIntoMap("", "", "", environments)
 
 	assert.Empty(t, environments, "expected an empty map")
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -27,7 +27,11 @@ func scheduleChecks(contentToCheck content.Content, publishDate time.Time, tid s
 				if absoluteUrlRegex.MatchString(metric.Endpoint) {
 					endpointURL, err = url.Parse(metric.Endpoint)
 				} else {
-					endpointURL, err = url.Parse(env.ReadUrl + metric.Endpoint)
+					if metric.Alias == "S3" {
+						endpointURL, err = url.Parse(env.S3Url + metric.Endpoint)
+					} else {
+						endpointURL, err = url.Parse(env.ReadUrl + metric.Endpoint)
+					}
 				}
 
 				if err != nil {

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"github.com/Financial-Times/publish-availability-monitor/content"
+	"github.com/stretchr/testify/require"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestValidType(testing *testing.T) {
@@ -28,4 +32,88 @@ func TestValidType(testing *testing.T) {
 			testing.Errorf("Test Case: %v\nActual: %v", t, actual)
 		}
 	}
+}
+
+var validImageEomFile = content.EomFile{
+	UUID:             "e28b12f7-9796-3331-b030-05082f0b8157",
+	Type:             "Image",
+	Value:            "/9j/4QAYRXhpZgAASUkqAAgAAAAAAAAAAAAAAP/sABFEdWNr",
+	Attributes:       "attributes",
+	SystemAttributes: "system attributes",
+}
+
+func TestScheduleChecksForS3AreCorrect(testing *testing.T) {
+	//redefine appConfig to have only S3
+	appConfig = &AppConfig{
+		MetricConf: []MetricConfig{
+			{
+				Endpoint:    "/whatever/",
+				Granularity: 1,
+				Alias:       "S3",
+				ContentTypes: []string{
+					"Image",
+				},
+			},
+		},
+		Threshold: 1,
+	}
+
+	var mockEnvironments = make(map[string]Environment)
+	s3ReadURL1 := "http://s1.example.org"
+	mockEnvironments["env1"] = Environment{"env1", "http://env1.example.org", s3ReadURL1, "user1", "pass1"}
+
+	capturingMetrics := runScheduleChecks(testing, mockEnvironments)
+
+	require.NotNil(testing, capturingMetrics)
+	require.Equal(testing, 1, len(capturingMetrics.publishMetrics))
+	require.Equal(testing, s3ReadURL1+"/whatever/", capturingMetrics.publishMetrics[0].endpoint.String())
+}
+
+func TestScheduleChecksForContentAreCorrect(testing *testing.T) {
+	//redefine appConfig to have only Content
+	appConfig = &AppConfig{
+		MetricConf: []MetricConfig{
+			{
+				Endpoint:    "/whatever/",
+				Granularity: 1,
+				Alias:       "content",
+				ContentTypes: []string{
+					"Image",
+				},
+			},
+		},
+		Threshold: 1,
+	}
+
+	var mockEnvironments = make(map[string]Environment)
+	readURL := "http://env1.example.org"
+	mockEnvironments["env1"] = Environment{"env1", readURL, "http://s1.example.org", "user1", "pass1"}
+
+	capturingMetrics := runScheduleChecks(testing, mockEnvironments)
+
+	require.NotNil(testing, capturingMetrics)
+	require.Equal(testing, 1, len(capturingMetrics.publishMetrics))
+	require.Equal(testing, readURL+"/whatever/", capturingMetrics.publishMetrics[0].endpoint.String())
+}
+
+func runScheduleChecks(testing *testing.T, mockEnvironments map[string]Environment) *publishHistory {
+	capturingMetrics := &publishHistory{sync.RWMutex{}, make([]PublishMetric, 0)}
+
+	tid := "tid_1234"
+	publishDate, err := time.Parse(dateLayout, "2016-01-08T14:22:06.271Z")
+	if err != nil {
+		testing.Error("Failure in setting up test data")
+		return nil
+	}
+
+	//redefine map to avoid actual checks
+	endpointSpecificChecks = map[string]EndpointSpecificCheck{}
+	//redefine metricSink to avoid hang
+	metricSink = make(chan PublishMetric, 2)
+
+	scheduleChecks(validImageEomFile, publishDate, tid, validImageEomFile.IsMarkedDeleted(), capturingMetrics, mockEnvironments)
+	for len(capturingMetrics.publishMetrics) != len(mockEnvironments) {
+		time.Sleep(1 * time.Second)
+	}
+	return capturingMetrics
 }

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -59,14 +59,15 @@ func TestScheduleChecksForS3AreCorrect(testing *testing.T) {
 	}
 
 	var mockEnvironments = make(map[string]Environment)
-	s3ReadURL1 := "http://s1.example.org"
-	mockEnvironments["env1"] = Environment{"env1", "http://env1.example.org", s3ReadURL1, "user1", "pass1"}
+	readURL := "http://env1.example.org"
+	s3URL := "http://s1.example.org"
+	mockEnvironments["env1"] = Environment{"env1", readURL, s3URL, "user1", "pass1"}
 
 	capturingMetrics := runScheduleChecks(testing, mockEnvironments)
 
 	require.NotNil(testing, capturingMetrics)
 	require.Equal(testing, 1, len(capturingMetrics.publishMetrics))
-	require.Equal(testing, s3ReadURL1+"/whatever/", capturingMetrics.publishMetrics[0].endpoint.String())
+	require.Equal(testing, s3URL+"/whatever/", capturingMetrics.publishMetrics[0].endpoint.String())
 }
 
 func TestScheduleChecksForContentAreCorrect(testing *testing.T) {
@@ -87,7 +88,8 @@ func TestScheduleChecksForContentAreCorrect(testing *testing.T) {
 
 	var mockEnvironments = make(map[string]Environment)
 	readURL := "http://env1.example.org"
-	mockEnvironments["env1"] = Environment{"env1", readURL, "http://s1.example.org", "user1", "pass1"}
+	s3URL := "http://s1.example.org"
+	mockEnvironments["env1"] = Environment{"env1", readURL, s3URL, "user1", "pass1"}
 
 	capturingMetrics := runScheduleChecks(testing, mockEnvironments)
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -100,7 +100,6 @@ func TestScheduleChecksForContentAreCorrect(testing *testing.T) {
 
 func runScheduleChecks(testing *testing.T, mockEnvironments map[string]Environment) *publishHistory {
 	capturingMetrics := &publishHistory{sync.RWMutex{}, make([]PublishMetric, 0)}
-
 	tid := "tid_1234"
 	publishDate, err := time.Parse(dateLayout, "2016-01-08T14:22:06.271Z")
 	if err != nil {


### PR DESCRIPTION
PAM will be configured to check different S3 location per region. 

The following etcd key should be configured: `/ft/config/monitoring/s3-urls`, having something like that: `env1:http://s3link1.org,env2:http://s3link1.org`