### PR TITLE
Match the parameter order in DiscoverEnvironmentsAndValidators.

### DIFF
--- a/app.go
+++ b/app.go
@@ -115,7 +115,7 @@ func main() {
 		return
 	}
 
-	go DiscoverEnvironmentsAndValidators(etcdPeers, etcdReadEnvKey, etcdS3EnvKey, etcdCredKey, etcdValidatorCredKey, environments)
+	go DiscoverEnvironmentsAndValidators(etcdPeers, etcdReadEnvKey, etcdCredKey, etcdS3EnvKey, etcdValidatorCredKey, environments)
 
 	metricContainer = publishHistory{sync.RWMutex{}, make([]PublishMetric, 0)}
 


### PR DESCRIPTION
This got fixed twice, independently, in different ways, and the fixes must have been merged without conflicts!