### PR TITLE
PAM Healthchecks

### DIFF
--- a/app.go
+++ b/app.go
@@ -49,6 +49,7 @@ type MetricConfig struct {
 	Endpoint     string   `json:"endpoint"`
 	ContentTypes []string `json:"contentTypes"` //list of valid eom types for this metric
 	Alias        string   `json:"alias"`
+	Health       string   `json:"health,omitempty"`
 }
 
 // SplunkConfig holds the SplunkFeeder-specific configuration

--- a/config.json.template
+++ b/config.json.template
@@ -1,83 +1,90 @@
 {
-	"threshold": 120,
-	"queueConfig": {
-		"address": ["QUEUE_ADDR"],
-		"group": "PubMonitor",
-		"topic": "NativeCmsPublicationEvents",
-		"queue": "KAFKA_PROXY_HOST",
-		"concurrentProcessing": true
-	},
-	"metricConfig": [{
-		"endpoint": "CONTENT_URL",
-		"alias": "content",
-		"health": "/__document-store-api/__health",
-		"granularity": 40,
-		"contentTypes": [
-			"EOM::CompoundStory",
-			"EOM::Story",
-			"Image",
-			"ImageSet",
-			"post", "webchat-markets-live", "webchat-live-blogs", "webchat-live-qa",
-			"video"
-		]
-	}, {
-		"endpoint": "/",
-		"granularity": 40,
-		"alias": "S3",
-		"contentTypes": [
-			"Image"
-		]
-	}, {
-		"endpoint": "LISTS_URL",
-		"granularity": 40,
-		"alias": "lists",
-		"health": "/__document-store-api/__health",
-		"contentTypes": [
-			"EOM::WebContainer"
-		]
-	}, {
-		"endpoint": "NOTIFICATIONS_URL",
-		"granularity": 40,
-		"alias": "notifications",
-		"health": "/__notifications-rw/__health",
-		"contentTypes": [
-			"EOM::CompoundStory",
-			"post"
-		]
-	}, {
-        "endpoint": "NOTIFICATIONS_PUSH_URL",
-        "granularity": 40,
-        "alias": "notifications-push",
-		  "health": "/__notifications-push/__health",
-        "contentTypes": [
-            "EOM::CompoundStory",
-            "post"
-        ]
-    }, {
-        "endpoint": "LISTS_NOTIFICATIONS_URL",
-        "granularity": 40,
-        "alias": "list-notifications",
-		  "health": "/__list-notifications-rw/__health",
-        "contentTypes": [
-            "EOM::WebContainer"
-        ]
-    }, {
-        "endpoint": "LISTS_NOTIFICATIONS_PUSH_URL",
-        "granularity": 40,
-        "alias": "list-notifications-push",
-		  "health": "/__list-notifications-push/__health",
-        "contentTypes": [
-            "EOM::WebContainer"
-        ]
-    }],
-	"splunk-config": {
-		"logPrefix": "[splunkMetrics] "
-	},
-	"healthConfig": {
-		"failureThreshold" : 2
-	},
-	"validationEndpoints": {
-		"EOM::CompoundStory": "METHODE_ARTICLE_TRANSFORMER_URL",
-		"EOM::Story": "METHODE_ARTICLE_TRANSFORMER_URL"
-	}
+   "threshold": 120,
+   "queueConfig": {
+      "address": ["QUEUE_ADDR"],
+      "group": "PubMonitor",
+      "topic": "NativeCmsPublicationEvents",
+      "queue": "KAFKA_PROXY_HOST",
+      "concurrentProcessing": true
+   },
+   "metricConfig": [{
+      "endpoint": "CONTENT_URL",
+      "alias": "content",
+      "health": "/__document-store-api/__health",
+      "granularity": 40,
+      "contentTypes": [
+         "EOM::CompoundStory",
+         "EOM::Story",
+         "Image",
+         "ImageSet",
+         "post", "webchat-markets-live", "webchat-live-blogs", "webchat-live-qa",
+         "video"
+      ]
+   },
+   {
+      "endpoint": "/",
+      "granularity": 40,
+      "alias": "S3",
+      "contentTypes": [
+         "Image"
+      ]
+   },
+   {
+      "endpoint": "LISTS_URL",
+      "granularity": 40,
+      "alias": "lists",
+      "health": "/__document-store-api/__health",
+      "contentTypes": [
+         "EOM::WebContainer"
+      ]
+   },
+   {
+      "endpoint": "NOTIFICATIONS_URL",
+      "granularity": 40,
+      "alias": "notifications",
+      "health": "/__notifications-rw/__health",
+      "contentTypes": [
+         "EOM::CompoundStory",
+         "post"
+      ]
+   },
+   {
+      "endpoint": "NOTIFICATIONS_PUSH_URL",
+      "granularity": 40,
+      "alias": "notifications-push",
+      "health": "/__notifications-push/__health",
+      "contentTypes": [
+         "EOM::CompoundStory",
+         "post"
+      ]
+   },
+   {
+      "endpoint": "LISTS_NOTIFICATIONS_URL",
+      "granularity": 40,
+      "alias": "list-notifications",
+      "health": "/__list-notifications-rw/__health",
+      "contentTypes": [
+         "EOM::WebContainer"
+      ]
+   },
+   {
+      "endpoint": "LISTS_NOTIFICATIONS_PUSH_URL",
+      "granularity": 40,
+      "alias": "list-notifications-push",
+      "health": "/__list-notifications-push/__health",
+      "contentTypes": [
+         "EOM::WebContainer"
+      ]
+   }
+],
+"splunk-config": {
+   "logPrefix": "[splunkMetrics] "
+},
+"healthConfig": {
+   "failureThreshold" : 2
+},
+"validationEndpoints": {
+   "EOM::CompoundStory": "METHODE_ARTICLE_TRANSFORMER_URL",
+   "EOM::Story": "METHODE_ARTICLE_TRANSFORMER_URL"
+}
 }

--- a/config.json.template
+++ b/config.json.template
@@ -10,6 +10,7 @@
 	"metricConfig": [{
 		"endpoint": "CONTENT_URL",
 		"alias": "content",
+		"health": "/__document-store-api/__health",
 		"granularity": 40,
 		"contentTypes": [
 			"EOM::CompoundStory",
@@ -30,6 +31,7 @@
 		"endpoint": "LISTS_URL",
 		"granularity": 40,
 		"alias": "lists",
+		"health": "/__document-store-api/__health",
 		"contentTypes": [
 			"EOM::WebContainer"
 		]
@@ -37,6 +39,7 @@
 		"endpoint": "NOTIFICATIONS_URL",
 		"granularity": 40,
 		"alias": "notifications",
+		"health": "/__notifications-rw/__health",
 		"contentTypes": [
 			"EOM::CompoundStory",
 			"post"
@@ -45,6 +48,7 @@
         "endpoint": "NOTIFICATIONS_PUSH_URL",
         "granularity": 40,
         "alias": "notifications-push",
+		  "health": "/__notifications-push/__health",
         "contentTypes": [
             "EOM::CompoundStory",
             "post"
@@ -53,6 +57,7 @@
         "endpoint": "LISTS_NOTIFICATIONS_URL",
         "granularity": 40,
         "alias": "list-notifications",
+		  "health": "/__list-notifications-rw/__health",
         "contentTypes": [
             "EOM::WebContainer"
         ]
@@ -60,6 +65,7 @@
         "endpoint": "LISTS_NOTIFICATIONS_PUSH_URL",
         "granularity": 40,
         "alias": "list-notifications-push",
+		  "health": "/__list-notifications-push/__health",
         "contentTypes": [
             "EOM::WebContainer"
         ]

--- a/feeds/baseNotificationsFeed.go
+++ b/feeds/baseNotificationsFeed.go
@@ -92,3 +92,7 @@ func (f *baseNotificationsFeed) NotificationsFor(uuid string) []*Notification {
 
 	return history
 }
+
+func (f *baseNotificationsFeed) FeedURL() string {
+	return f.baseUrl
+}

--- a/feeds/feedFactory.go
+++ b/feeds/feedFactory.go
@@ -49,6 +49,7 @@ func NewNotificationsFeed(name string, baseUrl *url.URL, sinceDate string, expir
 			},
 			true,
 			&sync.RWMutex{},
+			false,
 		}
 	}
 

--- a/feeds/model.go
+++ b/feeds/model.go
@@ -15,6 +15,7 @@ type Link struct {
 type Feed interface {
 	Start()
 	Stop()
+	IsConnected() bool
 	FeedName() string
 	FeedType() string
 	SetCredentials(username string, password string)

--- a/feeds/model.go
+++ b/feeds/model.go
@@ -15,8 +15,8 @@ type Link struct {
 type Feed interface {
 	Start()
 	Stop()
-	IsConnected() bool
 	FeedName() string
+	FeedURL() string
 	FeedType() string
 	SetCredentials(username string, password string)
 	NotificationsFor(uuid string) []*Notification

--- a/feeds/notificationsPullFeed.go
+++ b/feeds/notificationsPullFeed.go
@@ -54,10 +54,6 @@ func (f *NotificationsPullFeed) Stop() {
 	close(f.poller)
 }
 
-func (f *NotificationsPullFeed) IsConnected() bool {
-	return true // faking it for pull
-}
-
 func (f *NotificationsPullFeed) FeedType() string {
 	return NotificationsPull
 }

--- a/feeds/notificationsPullFeed.go
+++ b/feeds/notificationsPullFeed.go
@@ -54,6 +54,10 @@ func (f *NotificationsPullFeed) Stop() {
 	close(f.poller)
 }
 
+func (f *NotificationsPullFeed) IsConnected() bool {
+	return true // faking it for pull
+}
+
 func (f *NotificationsPullFeed) FeedType() string {
 	return NotificationsPull
 }

--- a/feeds/notificationsPushFeed.go
+++ b/feeds/notificationsPushFeed.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Financial-Times/publish-availability-monitor/checks"
 )
@@ -15,6 +16,7 @@ type NotificationsPushFeed struct {
 	baseNotificationsFeed
 	stopFeed     bool
 	stopFeedLock *sync.RWMutex
+	connected    bool
 }
 
 func (f *NotificationsPushFeed) Start() {
@@ -29,6 +31,8 @@ func (f *NotificationsPushFeed) Start() {
 		}
 
 		for f.consumeFeed() {
+			time.Sleep(500 * time.Millisecond)
+			infoLogger.Println("Disconnected from Push feed! Attempting to reconnect.")
 		}
 	}()
 }
@@ -43,6 +47,10 @@ func (f *NotificationsPushFeed) Stop() {
 
 func (f *NotificationsPushFeed) FeedType() string {
 	return NotificationsPush
+}
+
+func (f *NotificationsPushFeed) IsConnected() bool {
+	return f.connected
 }
 
 func (f *NotificationsPushFeed) isConsuming() bool {
@@ -66,6 +74,9 @@ func (f *NotificationsPushFeed) consumeFeed() bool {
 		return f.isConsuming()
 	}
 
+	infoLogger.Println("Reconnected to push feed!")
+	f.connected = true
+
 	br := bufio.NewReader(resp.Body)
 	for {
 		if !f.isConsuming() {
@@ -76,9 +87,9 @@ func (f *NotificationsPushFeed) consumeFeed() bool {
 
 		event, err := br.ReadString('\n')
 		if err != nil {
-			infoLogger.Printf("Error: [%v]", err)
-			panic("foo")
-			continue
+			infoLogger.Printf("Error: [%v] - disconnected from push feed!", err)
+			f.connected = false
+			return f.isConsuming()
 		}
 
 		trimmed := strings.TrimSpace(event)

--- a/feeds/notificationsPushFeed.go
+++ b/feeds/notificationsPushFeed.go
@@ -76,6 +76,7 @@ func (f *NotificationsPushFeed) consumeFeed() bool {
 
 	infoLogger.Println("Reconnected to push feed!")
 	f.connected = true
+	defer func() { f.connected = false }()
 
 	br := bufio.NewReader(resp.Body)
 	for {
@@ -88,7 +89,6 @@ func (f *NotificationsPushFeed) consumeFeed() bool {
 		event, err := br.ReadString('\n')
 		if err != nil {
 			infoLogger.Printf("Error: [%v] - disconnected from push feed!", err)
-			f.connected = false
 			return f.isConsuming()
 		}
 

--- a/feeds/notificationsPushFeed_test.go
+++ b/feeds/notificationsPushFeed_test.go
@@ -122,7 +122,7 @@ func TestPushNotificationsPollingContinuesAfterErrorResponse(t *testing.T) {
 	f.(*NotificationsPushFeed).SetHttpCaller(httpCaller)
 	f.Start()
 	defer f.Stop()
-	time.Sleep(time.Duration(50) * time.Millisecond)
+	time.Sleep(time.Duration(550) * time.Millisecond)
 
 	response := f.NotificationsFor(uuid)
 	assert.Len(t, response, 1, "notifications for item")

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -44,10 +44,11 @@ var noReadEnvironments = fthealth.Check{
 }
 
 func (h *Healthcheck) checkHealth(writer http.ResponseWriter, req *http.Request) {
-	checks := make([]fthealth.Check, 3)
+	checks := make([]fthealth.Check, 4)
 	checks[0] = h.messageQueueProxyReachable()
 	checks[1] = h.reflectPublishFailures()
 	checks[2] = h.validationServicesReachable()
+	checks[3] = isConsumingFromPushFeeds()
 
 	readEnvironmentChecks := h.readEnvironmentsReachable()
 	if len(readEnvironmentChecks) == 0 {
@@ -75,6 +76,32 @@ func (h *Healthcheck) gtg(writer http.ResponseWriter, req *http.Request) {
 	}
 }
 
+func isConsumingFromPushFeeds() fthealth.Check {
+	return fthealth.Check{
+		BusinessImpact:   "Publish metrics are not recorded. This will impact the SLA measurement.",
+		Name:             "IsConsumingFromNotificationsPushFeeds",
+		PanicGuide:       pam_run_book_url,
+		Severity:         1,
+		TechnicalSummary: "The connections to the configured notifications-push feeds are operating correctly.",
+		Checker: func() (string, error) {
+			result := true
+			for _, val := range subscribedFeeds {
+				for _, feed := range val {
+					if !feed.IsConnected() {
+						warnLogger.Println("Feed \"" + feed.FeedName() + "\" is not connected!")
+						result = false
+					}
+				}
+			}
+
+			if !result {
+				return "Disconnection detected.", errors.New("At least one of our Notifcations Push feeds in the delivery cluster is disconnected! Please review the logs, and check delivery healthchecks. We will attempt reconnection indefinitely, but there could be an issue with the delivery cluster's notifications-push services.")
+			}
+			return "", nil
+		},
+	}
+}
+
 func (h *Healthcheck) messageQueueProxyReachable() fthealth.Check {
 	return fthealth.Check{
 		BusinessImpact:   "Publish metrics are not recorded. This will impact the SLA measurement.",
@@ -84,7 +111,6 @@ func (h *Healthcheck) messageQueueProxyReachable() fthealth.Check {
 		TechnicalSummary: "Message queue proxy is not reachable/healthy",
 		Checker:          h.checkAggregateMessageQueueProxiesReachable,
 	}
-
 }
 
 func (h *Healthcheck) checkAggregateMessageQueueProxiesReachable() (string, error) {
@@ -201,8 +227,15 @@ func (h *Healthcheck) checkValidationServicesReachable() (string, error) {
 	hcErrs := make(chan error, len(endpoints))
 	for _, url := range endpoints {
 		wg.Add(1)
-		go checkServiceReachable("validation", url, h.client, hcErrs, &wg)
+		healthcheckURL, err := inferHealthCheckUrl(url)
+		if err != nil {
+			errorLogger.Printf("Validation Service URL: [%s]. Err: [%v]", url, err.Error())
+			continue
+		}
+
+		go checkServiceReachable(healthcheckURL, h.client, hcErrs, &wg)
 	}
+
 	wg.Wait()
 	close(hcErrs)
 	for err := range hcErrs {
@@ -213,29 +246,18 @@ func (h *Healthcheck) checkValidationServicesReachable() (string, error) {
 	return "", nil
 }
 
-func checkServiceReachable(serviceType string, serviceURL string, client http.Client, hcRes chan<- error, wg *sync.WaitGroup) {
+func checkServiceReachable(healthcheckURL string, client http.Client, hcRes chan<- error, wg *sync.WaitGroup) {
 	defer wg.Done()
+	infoLogger.Println("Checking: " + healthcheckURL)
 
-	var healthURL string
-	var err error
-	if fn, ok := readCheckEndpoints[serviceType]; ok {
-		healthURL, err = fn(serviceURL)
-	} else {
-		healthURL, err = buildFtHealthcheckUrl(serviceURL)
-	}
+	resp, err := client.Get(healthcheckURL)
 	if err != nil {
-		hcRes <- fmt.Errorf("Service URL: [%s]. Error: [%v]", serviceURL, err)
-		return
-	}
-
-	resp, err := client.Get(healthURL)
-	if err != nil {
-		hcRes <- fmt.Errorf("Healthcheck URL: [%s]. Error: [%v]", healthURL, err)
+		hcRes <- fmt.Errorf("Healthcheck URL: [%s]. Error: [%v]", healthcheckURL, err)
 		return
 	}
 	defer cleanupResp(resp)
 	if resp.StatusCode != 200 {
-		hcRes <- fmt.Errorf("Not healthy statusCode received: [%d]", resp.StatusCode)
+		hcRes <- fmt.Errorf("Unhealthy statusCode received: [%d] for URL [%s]", resp.StatusCode, healthcheckURL)
 		return
 	}
 	hcRes <- nil
@@ -270,7 +292,7 @@ func (h *readEnvironmentHealthcheck) checkReadEnvironmentReachable() (string, er
 		if absoluteUrlRegex.MatchString(metric.Endpoint) {
 			endpointURL, err = url.Parse(metric.Endpoint)
 		} else {
-			if (metric.Alias == "S3") {
+			if metric.Alias == "S3" {
 				endpointURL, err = url.Parse(h.env.S3Url + metric.Endpoint)
 			} else {
 				endpointURL, err = url.Parse(h.env.ReadUrl + metric.Endpoint)
@@ -278,12 +300,24 @@ func (h *readEnvironmentHealthcheck) checkReadEnvironmentReachable() (string, er
 		}
 
 		if err != nil {
-			errorLogger.Printf("Cannot parse url [%v], error: [%v]", metric.Endpoint, err.Error())
+			errorLogger.Printf("Cannot parse url [%v], Err: [%v]", metric.Endpoint, err.Error())
+			continue
+		}
+
+		var healthcheckURL string
+		if fn, ok := readCheckEndpoints[metric.Alias]; ok {
+			healthcheckURL, err = fn(endpointURL.String())
+		} else {
+			healthcheckURL, err = buildFtHealthcheckUrl(*endpointURL, metric.Health)
+		}
+
+		if err != nil {
+			errorLogger.Printf("Service URL: [%s]. Err: [%v]", endpointURL.String(), err.Error())
 			continue
 		}
 
 		wg.Add(1)
-		go checkServiceReachable(metric.Alias, endpointURL.String(), h.client, hcErrs, &wg)
+		go checkServiceReachable(healthcheckURL, h.client, hcErrs, &wg)
 	}
 
 	wg.Wait()
@@ -296,7 +330,7 @@ func (h *readEnvironmentHealthcheck) checkReadEnvironmentReachable() (string, er
 	return "", nil
 }
 
-func buildFtHealthcheckUrl(serviceUrl string) (string, error) {
+func inferHealthCheckUrl(serviceUrl string) (string, error) {
 	parsedURL, err := url.Parse(serviceUrl)
 	if err != nil {
 		return "", err
@@ -311,6 +345,12 @@ func buildFtHealthcheckUrl(serviceUrl string) (string, error) {
 
 	parsedURL.Path = newPath
 	return parsedURL.String(), nil
+}
+
+func buildFtHealthcheckUrl(endpoint url.URL, health string) (string, error) {
+	endpoint.Path = health
+	endpoint.RawQuery = "" // strip query params
+	return endpoint.String(), nil
 }
 
 func buildAwsHealthcheckUrl(serviceUrl string) (string, error) {

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -1,46 +1,32 @@
 package main
 
-import "testing"
+import (
+	"net/url"
+	"testing"
+)
 
 func TestBuildFtHealthcheckUrl(t *testing.T) {
 	var testCases = []struct {
 		validationURL     string
+		health            string
 		expectedHealthURL string
 	}{
 		{
 			validationURL:     "http://methode-article-transformer/content-transformer/",
-			expectedHealthURL: "http://methode-article-transformer/__health",
-		},
-		{
-			validationURL:     "http://methode-article-transformer/content-transformer",
-			expectedHealthURL: "http://methode-article-transformer/__health",
-		},
-		{
-			validationURL:     "http://methode-article-transformer/__methode-article-transformer/content-transformer",
+			health:            "/__methode-article-transformer/__health",
 			expectedHealthURL: "http://methode-article-transformer/__methode-article-transformer/__health",
 		},
 		{
-			validationURL:     "http://methode-article-transformer",
-			expectedHealthURL: "http://methode-article-transformer/__health",
-		},
-		{
-			validationURL:     "http://methode-article-transformer:8080",
-			expectedHealthURL: "http://methode-article-transformer:8080/__health",
-		},
-		{
-			validationURL:     "http://localhost:8080/__methode-article-transformer/content-transformer/",
-			expectedHealthURL: "http://localhost:8080/__methode-article-transformer/__health",
-		},
-		{
-			validationURL:     "http://coco.example.com/__notifications-rw/content/notifications",
-			expectedHealthURL: "http://coco.example.com/__notifications-rw/__health",
+			validationURL:     "http://methode-article-transformer/content-transformer?monitor=true",
+			health:            "/__methode-article-transformer/__health",
+			expectedHealthURL: "http://methode-article-transformer/__methode-article-transformer/__health",
 		},
 	}
 	for _, tc := range testCases {
-		if actual, _ := buildFtHealthcheckUrl(tc.validationURL); actual != tc.expectedHealthURL {
+		uri, _ := url.Parse(tc.validationURL)
+		if actual, _ := buildFtHealthcheckUrl(*uri, tc.health); actual != tc.expectedHealthURL {
 			t.Errorf("For [%s]:\n\tExpected: [%s]\n\tActual: [%s]", tc.validationURL, tc.expectedHealthURL, actual)
 		}
-
 	}
 }
 


### PR DESCRIPTION
PAM now checks the health of the push connection (rather than just the `__health` endpoint)
There are also improvements to the healthcheck logic.