### PR TITLE
Remove uuid from external validation URL

### DIFF
--- a/content/methodeContent.go
+++ b/content/methodeContent.go
@@ -214,7 +214,7 @@ func isExternalValidationSuccessful(eomfile EomFile, validationURL string, txId,
 	}
 
 	resp, err := httpCaller.DoCallWithEntity(
-		"POST", validationURL+"/"+eomfile.UUID,
+		"POST", validationURL,
 		username, password,
 		checks.ConstructPamTxId(txId),
 		"application/json", bytes.NewReader(marshalled))


### PR DESCRIPTION
I removed the appending of the UUID to the external validation URL to match the mapping endpoints of the mappers.