### PR TITLE
Change PAM so it requires two *different* uuids to fail publishing to…

### DIFF
--- a/app.go
+++ b/app.go
@@ -161,7 +161,7 @@ func attachProfiler(router *mux.Router) {
 }
 
 func readMessages() {
-	c := consumer.NewConsumer(appConfig.QueueConf, handleMessage, http.Client{})
+	c := consumer.NewConsumer(appConfig.QueueConf, handleMessage, &http.Client{})
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"github.com/stretchr/testify/assert"
+	"net/http"
 	"net/url"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestBuildFtHealthcheckUrl(t *testing.T) {
@@ -46,4 +50,43 @@ func TestBuildAwsHealthcheckUrl(t *testing.T) {
 		}
 
 	}
+
+}
+
+func TestPublishNoFailuresForSametUUIDs(t *testing.T) {
+	assert := assert.New(t)
+	config := MetricConfig{}
+	interval := Interval{5, 5}
+	newUrl := url.URL{}
+	t0 := time.Now()
+	var publishMetric1 = PublishMetric{"1234567", false, t0, "", interval, config, newUrl, "tid_1234", false}
+	var publishMetric2 = PublishMetric{"1234567", false, t0, "", interval, config, newUrl, "tid_6789", false}
+	var publishMetric3 = PublishMetric{"1234567", false, t0, "", interval, config, newUrl, "tid_6789", false}
+	var testMetrics = []PublishMetric{publishMetric1, publishMetric2, publishMetric3}
+
+	var testPublishHistory = publishHistory{sync.RWMutex{}, testMetrics}
+	var testHealthcheck = Healthcheck{http.Client{}, AppConfig{}, &testPublishHistory}
+	_, err := testHealthcheck.checkForPublishFailures()
+
+	assert.NoError(err, "No Error expected if multiple fails for the same uuid")
+
+}
+
+func TestPublishFailureForDistinctUUIDs(t *testing.T) {
+	assert := assert.New(t)
+	config := MetricConfig{}
+	interval := Interval{5, 5}
+	newUrl := url.URL{}
+	t0 := time.Now()
+	var publishMetric1 = PublishMetric{"12345", false, t0, "", interval, config, newUrl, "tid_1234", false}
+	var publishMetric2 = PublishMetric{"12678", false, t0, "", interval, config, newUrl, "tid_6789", false}
+	var publishMetric3 = PublishMetric{"12679", true, t0, "", interval, config, newUrl, "tid_6789", false}
+	var testMetrics = []PublishMetric{publishMetric1, publishMetric2, publishMetric3}
+
+	testPublishHistory := publishHistory{sync.RWMutex{}, testMetrics}
+
+	testHealthcheck := Healthcheck{http.Client{}, AppConfig{}, &testPublishHistory}
+	_, err := testHealthcheck.checkForPublishFailures()
+
+	assert.Error(err, "Expected Error for at least two distinct uuid publish fails")
 }


### PR DESCRIPTION
… have a failing publish healthcheck