### PR TITLE
Improved logging messages for external validations

### DIFF
--- a/content/content.go
+++ b/content/content.go
@@ -19,7 +19,7 @@ type Content interface {
 }
 
 type ValidationResponse struct {
-	IsValid bool
+	IsValid         bool
 	IsMarkedDeleted bool
 }
 

--- a/content/methodeContent.go
+++ b/content/methodeContent.go
@@ -48,12 +48,12 @@ func (eomfile EomFile) Validate(externalValidationEndpoint string, txID string, 
 	contentUUID := eomfile.UUID
 	if !isUUIDValid(contentUUID) {
 		warnLogger.Printf("Eomfile invalid: invalid UUID: [%s]. transaction_id=[%s]", contentUUID, txID)
-		return ValidationResponse{IsValid:false}
+		return ValidationResponse{IsValid: false}
 	}
 
 	isValid, statusCode := isExternalValidationSuccessful(eomfile, externalValidationEndpoint, txID, username, password)
 
-	return ValidationResponse{IsValid:isValid, IsMarkedDeleted: eomfile.isMarkedDeleted(statusCode)}
+	return ValidationResponse{IsValid: isValid, IsMarkedDeleted: eomfile.isMarkedDeleted(statusCode)}
 }
 
 func (eomfile EomFile) isMarkedDeleted(validationStatusCode int) bool {
@@ -84,7 +84,7 @@ func isExternalValidationSuccessful(eomfile EomFile, validationURL string, txID,
 	}
 	marshalled, err := json.Marshal(eomfile)
 	if err != nil {
-		warnLogger.Printf("External validation for content uuid=[%s] transaction_id=[%s] error: [%v]. Skipping external validation.", eomfile.UUID, txID, err)
+		warnLogger.Printf("External validation for content uuid=[%s] transaction_id=[%s] validationURL=[%s], marshalling EOM File error: [%v]. Skipping external validation.", eomfile.UUID, txID, validationURL, err)
 		return true, 0
 	}
 
@@ -95,20 +95,20 @@ func isExternalValidationSuccessful(eomfile EomFile, validationURL string, txID,
 		"application/json", bytes.NewReader(marshalled))
 
 	if err != nil {
-		warnLogger.Printf("External validation for content uuid=[%s] transaction_id=[%s] error: [%v]. Skipping external validation.", eomfile.UUID, txID, err)
+		warnLogger.Printf("External validation for content uuid=[%s] transaction_id=[%s] validationURL=[%s], create request error: [%v]. Skipping external validation.", eomfile.UUID, txID, validationURL, err)
 		return true, 0
 	}
 	defer cleanupResp(resp)
 
-	infoLogger.Printf("External validation for content uuid=[%s] transaction_id=[%s] received statusCode [%d]", eomfile.UUID, txID, resp.StatusCode)
+	infoLogger.Printf("External validation for content uuid=[%s] transaction_id=[%s] validationURL=[%s], received statusCode [%d]", eomfile.UUID, txID, validationURL, resp.StatusCode)
 
 	bs, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		warnLogger.Printf("External validation for content uuid=[%s] transaction_id=[%s] error: [%v]", eomfile.UUID, txID, err)
+		warnLogger.Printf("External validation for content uuid=[%s] transaction_id=[%s] validationURL=[%s], reading response body error: [%v]", eomfile.UUID, txID, validationURL, err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		infoLogger.Printf("External validation for content uuid=[%s] transaction_id=[%s] error: [%v]", eomfile.UUID, txID, string(bs))
+		infoLogger.Printf("External validation for content uuid=[%s] transaction_id=[%s] validationURL=[%s], received statusCode [%d], received error: [%v]", eomfile.UUID, txID, validationURL, resp.StatusCode, string(bs))
 	}
 
 	// 422 invalid  contentplaceholder (link file) will not be published so do not monitor

--- a/content/video.go
+++ b/content/video.go
@@ -20,13 +20,13 @@ func (v Video) Validate(externalValidationEndpoint string, txId string, username
 	contentUUID := v.UUID
 	if !isUUIDValid(contentUUID) {
 		warnLogger.Printf("Video invalid: invalid UUID: [%s]", contentUUID)
-		return ValidationResponse{IsValid:false, IsMarkedDeleted: v.isMarkedDeleted()}
+		return ValidationResponse{IsValid: false, IsMarkedDeleted: v.isMarkedDeleted()}
 	}
 	if !idRegexp.MatchString(v.Id) {
 		warnLogger.Printf("Video invalid: invalid ID: [%s]", v.Id)
-		return ValidationResponse{IsValid:false, IsMarkedDeleted: v.isMarkedDeleted()}
+		return ValidationResponse{IsValid: false, IsMarkedDeleted: v.isMarkedDeleted()}
 	}
-	return ValidationResponse{IsValid:true, IsMarkedDeleted: v.isMarkedDeleted()}
+	return ValidationResponse{IsValid: true, IsMarkedDeleted: v.isMarkedDeleted()}
 }
 
 func (v Video) isMarkedDeleted() bool {

--- a/content/wordPressContent.go
+++ b/content/wordPressContent.go
@@ -32,29 +32,29 @@ type Post struct {
 func (wordPressMessage WordPressMessage) Validate(extValEndpoint string, txId string, username string, password string) ValidationResponse {
 	if wordPressMessage.Status == "error" && wordPressMessage.Error != notFoundError {
 		//it's an error which we do not understand
-		return ValidationResponse{IsValid:false, IsMarkedDeleted: wordPressMessage.isMarkedDeleted()}
+		return ValidationResponse{IsValid: false, IsMarkedDeleted: wordPressMessage.isMarkedDeleted()}
 	}
 
 	contentUUID := wordPressMessage.Post.UUID
 	if !isUUIDValid(contentUUID) {
 		warnLogger.Printf("WordPress message invalid: invalid UUID: [%s]", contentUUID)
-		return ValidationResponse{IsValid:false, IsMarkedDeleted: wordPressMessage.isMarkedDeleted()}
+		return ValidationResponse{IsValid: false, IsMarkedDeleted: wordPressMessage.isMarkedDeleted()}
 	}
 
 	postURL := wordPressMessage.Post.Url
 	if !isValidBrand(postURL) {
 		warnLogger.Printf("WordPress message invalid: failed to resolve brand for uri [%s].", postURL)
-		return ValidationResponse{IsValid:false, IsMarkedDeleted: wordPressMessage.isMarkedDeleted()}
+		return ValidationResponse{IsValid: false, IsMarkedDeleted: wordPressMessage.isMarkedDeleted()}
 	}
 
 	contentType := wordPressMessage.Post.Type
 	for _, validType := range validWordPressTypes {
 		if contentType == validType {
-			return ValidationResponse{IsValid:true, IsMarkedDeleted: wordPressMessage.isMarkedDeleted()}
+			return ValidationResponse{IsValid: true, IsMarkedDeleted: wordPressMessage.isMarkedDeleted()}
 		}
 	}
 	warnLogger.Printf("WordPress message invalid: unexpected content type: [%s]", contentType)
-	return ValidationResponse{IsValid:false, IsMarkedDeleted: wordPressMessage.isMarkedDeleted()}
+	return ValidationResponse{IsValid: false, IsMarkedDeleted: wordPressMessage.isMarkedDeleted()}
 }
 
 func (wordPressMessage WordPressMessage) isMarkedDeleted() bool {

--- a/content/wordPressContent_test.go
+++ b/content/wordPressContent_test.go
@@ -34,14 +34,14 @@ var wordpressContentWithInvalidBlogDomain = WordPressMessage{
 
 func TestIsValidBlogDomain_True(t *testing.T) {
 	valRes := wordpressContentWithValidBlogDomain.Validate("", "", "", "")
-	if !valRes.IsValid{
+	if !valRes.IsValid {
 		t.Error("Expected True")
 	}
 }
 
 func TestIsValidBlogDomain_False(t *testing.T) {
 	valRes := wordpressContentWithInvalidBlogDomain.Validate("", "", "", "")
-	if valRes.IsValid{
+	if valRes.IsValid {
 		t.Error("Expected False")
 	}
 }


### PR DESCRIPTION
The main reason for doing this is to be able to differentiate in logs between the 2 validation calls that are done for an Article, the one to MAM and to MAICM. 

As a solution I've added validation URL to the logging message to be able to differentiate the 2 validations.

Also ran go fmt.