### PR TITLE
Http client retries

### DIFF
--- a/checks/httpCaller.go
+++ b/checks/httpCaller.go
@@ -58,8 +58,8 @@ func (c defaultHttpCaller) DoCall(config Config) (resp *http.Response, err error
 
 	req.Header.Add("User-Agent", "UPP Publish Availability Monitor")
 
-	var httpError error
 	op := func() error {
+		var httpError error
 		resp, httpError = c.client.Do(req)
 		if httpError != nil {
 			err = httpError

--- a/checks/httpCaller.go
+++ b/checks/httpCaller.go
@@ -1,6 +1,8 @@
 package checks
 
 import (
+	"fmt"
+	"github.com/giantswarm/retry-go"
 	"io"
 	"net/http"
 	"time"
@@ -56,5 +58,19 @@ func (c defaultHttpCaller) DoCall(config Config) (resp *http.Response, err error
 
 	req.Header.Add("User-Agent", "UPP Publish Availability Monitor")
 
-	return c.client.Do(req)
+	var httpError error
+	op := func() error {
+		resp, httpError = c.client.Do(req)
+		if httpError != nil {
+			err = httpError
+		}
+		if resp.StatusCode >= 500 && resp.StatusCode < 600 {
+			//Error status code: create an err in order to trigger a retry
+			httpError = fmt.Errorf("Error status code received: %d", resp.StatusCode)
+		}
+		return httpError
+	}
+
+	retry.Do(op, retry.RetryChecker(func(err error) bool { return err != nil }), retry.MaxTries(2), retry.Sleep(1*time.Second))
+	return resp, err
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -107,6 +107,12 @@
 			"revisionTime": "2017-02-02T08:07:59Z"
 		},
 		{
+			"checksumSHA1": "8S4DTF5nyldGBZ3FIJ9I0SrU9JM=",
+			"path": "github.com/juju/errgo",
+			"revision": "08cceb5d0b5331634b9826762a8fd53b29b86ad8",
+			"revisionTime": "2014-09-25T10:02:37Z"
+		},
+		{
 			"checksumSHA1": "eOXF2PEvYLMeD8DSzLZJWbjYzco=",
 			"path": "github.com/kr/pretty",
 			"revision": "cfb55aafdaf3ec08f0db22699ab822c50091b1c4",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -81,6 +81,12 @@
 			"revisionTime": "2016-10-29T20:57:26Z"
 		},
 		{
+			"checksumSHA1": "5pJ0FKl1ueYmWd6OwSNAxTt9rS4=",
+			"path": "github.com/giantswarm/retry-go",
+			"revision": "d78cea247d5e87d005ff7732f88bc52359afbe19",
+			"revisionTime": "2015-12-03T10:29:09Z"
+		},
+		{
 			"checksumSHA1": "g/V4qrXjUGG9B+e3hB+4NAYJ5Gs=",
 			"path": "github.com/gorilla/context",
 			"revision": "08b5f424b9271eedf6f9f0ce86cb9396ed337a42",


### PR DESCRIPTION
The HTTP client used by PAM should retry failed request in order to avoid alerting on connectivity issues that randomly happen.