### PR TITLE
Enable pull notifications capability monitoring

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -135,6 +135,11 @@
       "name": "push-notifications",
       "metricAlias": "notifications-push",
       "testIDs": ["427f2a19-2ae7-47c1-b580-c225fa0a0199"]
+    },
+    {
+      "name": "pull-notifications",
+      "metricAlias": "notifications",
+      "testIDs": ["427f2a19-2ae7-47c1-b580-c225fa0a0199"]
     }
   ],
   "graphiteAddress": "GRAPHITE_ADDRESS",

--- a/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_dev.yaml
+++ b/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_dev.yaml
@@ -13,6 +13,7 @@ envs:
   internal_components_url: "/__document-store-api/internalcomponents/"
   lists_url: "/__document-store-api/lists/"
   notifications_url: "/__notifications-rw/content/notifications?type=all"
+  notifications_url_param2: "monitor=true"
   # I had to split the URL into 2 parts because I couldn't find a way to put the exact string \& in the value
   # This way I moved handling that value in the template chart where it seems it doesn't have a problem with it.
   notifications_push_url:  "/content/notifications-push?monitor=true"

--- a/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_prod.yaml
+++ b/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_prod.yaml
@@ -13,6 +13,7 @@ envs:
   internal_components_url: "/__document-store-api/internalcomponents/"
   lists_url: "/__document-store-api/lists/"
   notifications_url: "/__notifications-rw/content/notifications?type=all"
+  notifications_url_param2: "monitor=true"
   # I had to split the URL into 2 parts because I couldn't find a way to put the exact string \& in the value
   # This way I moved handling that value in the template chart where it seems it doesn't have a problem with it.
   notifications_push_url:  "/content/notifications-push?monitor=true"

--- a/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_staging.yaml
+++ b/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_staging.yaml
@@ -13,6 +13,7 @@ envs:
   internal_components_url: "/__document-store-api/internalcomponents/"
   lists_url: "/__document-store-api/lists/"
   notifications_url: "/__notifications-rw/content/notifications?type=all"
+  notifications_url_param2: "monitor=true"
   # I had to split the URL into 2 parts because I couldn't find a way to put the exact string \& in the value
   # This way I moved handling that value in the template chart where it seems it doesn't have a problem with it.
   notifications_push_url:  "/content/notifications-push?monitor=true"

--- a/helm/publish-availability-monitor/templates/deployment.yaml
+++ b/helm/publish-availability-monitor/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
         - name: LISTS_URL
           value: "{{ .Values.envs.lists_url }}"
         - name: NOTIFICATIONS_URL
-          value: "{{ .Values.envs.notifications_url }}"
+          value: {{ .Values.envs.notifications_url }}\&{{ .Values.envs.notifications_url_param2 }}
         - name: NOTIFICATIONS_PUSH_URL
           value: {{ .Values.envs.notifications_push_url }}\&{{ .Values.envs.notifications_push_url_param2 }}
         - name: LISTS_NOTIFICATIONS_URL


### PR DESCRIPTION
# Description

## What

The implementation was done in https://github.com/Financial-Times/publish-availability-monitor/pull/179, here we are just adding config that should enable the pull notifications capability monitoring.

## Why

[JIRA ticket](https://financialtimes.atlassian.net/browse/UPPSF-1884).

## Anything, in particular, you'd like to highlight to reviewers

The metrics can be found at https://graphitev2-api.ft.com under `Metrics/content-metadata/capability-monitoring/pull-notifications` directory. Again, the status metric will currently have only 0 values (meaning failing) because we have not implemented the needed change in notifications-rw service.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
