### PR TITLE
Enable generic publishing monitoring

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -23,7 +23,8 @@
         "Image",
         "ImageSet",
         "video",
-        "wordpress"
+        "wordpress",
+        "application/vnd.ft-upp-article-internal"
       ]
     },
     {
@@ -35,7 +36,8 @@
         "EOM::CompoundStory",
         "EOM::CompoundStory_DynamicContent",
         "EOM::Story",
-        "wordpress"
+        "wordpress",
+        "application/vnd.ft-upp-article-internal"
       ]
     },
     {
@@ -74,7 +76,8 @@
         "EOM::CompoundStory",
         "EOM::CompoundStory_External_CPH",
         "EOM::CompoundStory_Internal_CPH",
-        "EOM::CompoundStory_DynamicContent"
+        "EOM::CompoundStory_DynamicContent",
+        "application/vnd.ft-upp-article-internal"
       ]
     },
     {
@@ -87,7 +90,8 @@
         "EOM::CompoundStory",
         "EOM::CompoundStory_External_CPH",
         "EOM::CompoundStory_Internal_CPH",
-        "wordpress"
+        "wordpress",
+        "application/vnd.ft-upp-article-internal"
       ]
     },
     {
@@ -106,7 +110,8 @@
       "health": "/__document-store-api/__health",
       "contentTypes": [
         "InternalComponents",
-        "EOM::CompoundStory_DynamicContent"
+        "EOM::CompoundStory_DynamicContent",
+        "application/vnd.ft-upp-article-internal"
       ]
     }
   ],

--- a/config.json.template
+++ b/config.json.template
@@ -68,6 +68,15 @@
       ]
     },
     {
+      "endpoint": "GENERIC_LISTS_URL",
+      "granularity": 40,
+      "alias": "generic-lists",
+      "health": "/__document-store-api/__health",
+      "contentTypes": [
+        "application/vnd.ft-upp-list"
+      ]
+    },
+    {
       "endpoint": "NOTIFICATIONS_URL",
       "granularity": 40,
       "alias": "notifications",
@@ -100,7 +109,8 @@
       "alias": "list-notifications",
       "health": "/__list-notifications-rw/__health",
       "contentTypes": [
-        "EOM::WebContainer"
+        "EOM::WebContainer",
+        "application/vnd.ft-upp-list"
       ]
     },
     {
@@ -132,7 +142,8 @@
     "InternalComponents": "METHODE_ARTICLE_INTERNAL_COMPONENTS_MAPPER_URL",
     "video": "VIDEO_MAPPER_URL",
     "wordpress": "WORDPRESS_MAPPER_URL",
-    "application/vnd.ft-upp-article-internal": "UPP_INTERNAL_ARTICLE_VALIDATOR_URL"
+    "application/vnd.ft-upp-article-internal": "UPP_INTERNAL_ARTICLE_VALIDATOR_URL",
+    "application/vnd.ft-upp-list": "UPP_LIST_VALIDATOR_URL"
   },
   "uuidResolverUrl": "UUID_RESOLVER_URL",
   "capabilities": [

--- a/config.json.template
+++ b/config.json.template
@@ -24,7 +24,8 @@
         "ImageSet",
         "video",
         "wordpress",
-        "application/vnd.ft-upp-article-internal"
+        "application/vnd.ft-upp-article-internal",
+        "application/vnd.ft-upp-content-placeholder-internal"
       ]
     },
     {
@@ -47,7 +48,8 @@
       "granularity": 40,
       "contentTypes": [
         "EOM::CompoundStory_External_CPH",
-        "EOM::CompoundStory_Internal_CPH"
+        "EOM::CompoundStory_Internal_CPH",
+        "application/vnd.ft-upp-content-placeholder-internal"
       ]
     },
     {
@@ -86,7 +88,8 @@
         "EOM::CompoundStory_External_CPH",
         "EOM::CompoundStory_Internal_CPH",
         "EOM::CompoundStory_DynamicContent",
-        "application/vnd.ft-upp-article-internal"
+        "application/vnd.ft-upp-article-internal",
+        "application/vnd.ft-upp-content-placeholder-internal"
       ]
     },
     {
@@ -143,7 +146,8 @@
     "video": "VIDEO_MAPPER_URL",
     "wordpress": "WORDPRESS_MAPPER_URL",
     "application/vnd.ft-upp-article-internal": "UPP_INTERNAL_ARTICLE_VALIDATOR_URL",
-    "application/vnd.ft-upp-list": "UPP_LIST_VALIDATOR_URL"
+    "application/vnd.ft-upp-list": "UPP_LIST_VALIDATOR_URL",
+    "application/vnd.ft-upp-content-placeholder-internal": "UPP_INTERNAL_CPH_VALIDATOR_URL"
   },
   "uuidResolverUrl": "UUID_RESOLVER_URL",
   "capabilities": [

--- a/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_dev.yaml
+++ b/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_dev.yaml
@@ -31,6 +31,7 @@ envs:
     wordpress_mapper: "__wordpress-article-mapper/map"
     upp_internal_article_validator: "__upp-internal-article-validator/validate"
     upp_list_validator: "__upp-list-validator/validate"
+    upp_internal_cph_validator: "__upp-internal-content-placeholder-validator/validate"
   uuid_resolver_url: "/__document-store-api"
 
 cluster:

--- a/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_dev.yaml
+++ b/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_dev.yaml
@@ -12,6 +12,7 @@ envs:
   complementary_content_url: "/__document-store-api/complementarycontent/"
   internal_components_url: "/__document-store-api/internalcomponents/"
   lists_url: "/__document-store-api/lists/"
+  generic_lists_url: "/__document-store-api/generic-lists/"
   notifications_url: "/__notifications-rw/content/notifications?type=all"
   notifications_url_param2: "monitor=true"
   # I had to split the URL into 2 parts because I couldn't find a way to put the exact string \& in the value
@@ -29,6 +30,7 @@ envs:
     video_mapper: "__upp-next-video-mapper/map"
     wordpress_mapper: "__wordpress-article-mapper/map"
     upp_internal_article_validator: "__upp-internal-article-validator/validate"
+    upp_list_validator: "__upp-list-validator/validate"
   uuid_resolver_url: "/__document-store-api"
 
 cluster:

--- a/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_prod.yaml
+++ b/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_prod.yaml
@@ -31,6 +31,7 @@ envs:
     wordpress_mapper: "__wordpress-article-mapper/map"
     upp_internal_article_validator: "__upp-internal-article-validator/validate"
     upp_list_validator: "__upp-list-validator/validate"
+    upp_internal_cph_validator: "__upp-internal-content-placeholder-validator/validate"
   uuid_resolver_url: "/__document-store-api"
 
 cluster:

--- a/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_prod.yaml
+++ b/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_prod.yaml
@@ -12,6 +12,7 @@ envs:
   complementary_content_url: "/__document-store-api/complementarycontent/"
   internal_components_url: "/__document-store-api/internalcomponents/"
   lists_url: "/__document-store-api/lists/"
+  generic_lists_url: "/__document-store-api/generic-lists/"
   notifications_url: "/__notifications-rw/content/notifications?type=all"
   notifications_url_param2: "monitor=true"
   # I had to split the URL into 2 parts because I couldn't find a way to put the exact string \& in the value
@@ -29,6 +30,7 @@ envs:
     video_mapper: "__upp-next-video-mapper/map"
     wordpress_mapper: "__wordpress-article-mapper/map"
     upp_internal_article_validator: "__upp-internal-article-validator/validate"
+    upp_list_validator: "__upp-list-validator/validate"
   uuid_resolver_url: "/__document-store-api"
 
 cluster:

--- a/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_staging.yaml
+++ b/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_staging.yaml
@@ -31,6 +31,7 @@ envs:
     wordpress_mapper: "__wordpress-article-mapper/map"
     upp_internal_article_validator: "__upp-internal-article-validator/validate"
     upp_list_validator: "__upp-list-validator/validate"
+    upp_internal_cph_validator: "__upp-internal-content-placeholder-validator/validate"
   uuid_resolver_url: "/__document-store-api"
 
 cluster:

--- a/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_staging.yaml
+++ b/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_staging.yaml
@@ -12,6 +12,7 @@ envs:
   complementary_content_url: "/__document-store-api/complementarycontent/"
   internal_components_url: "/__document-store-api/internalcomponents/"
   lists_url: "/__document-store-api/lists/"
+  generic_lists_url: "/__document-store-api/generic-lists/"
   notifications_url: "/__notifications-rw/content/notifications?type=all"
   notifications_url_param2: "monitor=true"
   # I had to split the URL into 2 parts because I couldn't find a way to put the exact string \& in the value
@@ -29,6 +30,7 @@ envs:
     video_mapper: "__upp-next-video-mapper/map"
     wordpress_mapper: "__wordpress-article-mapper/map"
     upp_internal_article_validator: "__upp-internal-article-validator/validate"
+    upp_list_validator: "__upp-list-validator/validate"
   uuid_resolver_url: "/__document-store-api"
 
 cluster:

--- a/helm/publish-availability-monitor/templates/deployment.yaml
+++ b/helm/publish-availability-monitor/templates/deployment.yaml
@@ -59,6 +59,8 @@ spec:
           value: "{{ .Values.envs.internal_components_url }}"
         - name: LISTS_URL
           value: "{{ .Values.envs.lists_url }}"
+        - name: GENERIC_LISTS_URL
+          value: "{{ .Values.envs.generic_lists_url }}"
         - name: NOTIFICATIONS_URL
           value: {{ .Values.envs.notifications_url }}\&{{ .Values.envs.notifications_url_param2 }}
         - name: NOTIFICATIONS_PUSH_URL
@@ -101,6 +103,8 @@ spec:
           value: "{{ $base_url }}/{{ .Values.envs.validation_endpoints.wordpress_mapper }}"
         - name: UPP_INTERNAL_ARTICLE_VALIDATOR_URL
           value: "{{ $base_url }}/{{ .Values.envs.validation_endpoints.upp_internal_article_validator }}"
+        - name: UPP_LIST_VALIDATOR_URL
+          value: "{{ $base_url }}/{{ .Values.envs.validation_endpoints.upp_list_validator }}"
         - name: UUID_RESOLVER_URL
           value: "{{ .Values.envs.uuid_resolver_url }}"
         ports:

--- a/helm/publish-availability-monitor/templates/deployment.yaml
+++ b/helm/publish-availability-monitor/templates/deployment.yaml
@@ -105,6 +105,8 @@ spec:
           value: "{{ $base_url }}/{{ .Values.envs.validation_endpoints.upp_internal_article_validator }}"
         - name: UPP_LIST_VALIDATOR_URL
           value: "{{ $base_url }}/{{ .Values.envs.validation_endpoints.upp_list_validator }}"
+        - name: UPP_INTERNAL_CPH_VALIDATOR_URL
+          value: "{{ $base_url }}/{{ .Values.envs.validation_endpoints.upp_internal_cph_validator }}"
         - name: UUID_RESOLVER_URL
           value: "{{ .Values.envs.uuid_resolver_url }}"
         ports:

--- a/helm/publish-availability-monitor/values.yaml
+++ b/helm/publish-availability-monitor/values.yaml
@@ -12,6 +12,7 @@ envs:
   complementary_content_url: ""
   internal_components_url: ""
   lists_url: ""
+  generic_lists_url: ""
   notifications_url: ""
   notifications_push_url: ""
   lists_notifications_url: ""

--- a/messageHandler.go
+++ b/messageHandler.go
@@ -99,6 +99,7 @@ func (h *kafkaMessageHandler) HandleMessage(msg consumer.Message) {
 		"S3":                      checks.NewS3Check(hC),
 		"enrichedContent":         checks.NewContentCheck(hC),
 		"lists":                   checks.NewContentCheck(hC),
+		"generic-lists":           checks.NewContentCheck(hC),
 		"notifications":           checks.NewNotificationsCheck(hC, h.subscribedFeeds, "notifications"),
 		"notifications-push":      checks.NewNotificationsCheck(hC, h.subscribedFeeds, "notifications-push"),
 		"list-notifications":      checks.NewNotificationsCheck(hC, h.subscribedFeeds, "list-notifications"),
@@ -171,7 +172,7 @@ func (h *kafkaMessageHandler) unmarshalContent(msg consumer.Message) (content.Co
 			return nil, err
 		}
 		return video.Initialize(binaryContent), nil
-	case "http://cmdb.ft.com/systems/cct":
+	case "http://cmdb.ft.com/systems/cct", "http://cmdb.ft.com/systems/spark-lists", "http://cmdb.ft.com/systems/spark":
 		var genericContent content.GenericContent
 		err := json.Unmarshal(binaryContent, &genericContent)
 		if err != nil {

--- a/startup.sh
+++ b/startup.sh
@@ -23,6 +23,7 @@ sed -i "s \"VIDEO_MAPPER_URL\" \"$VIDEO_MAPPER_URL\" " /config.json
 sed -i "s \"WORDPRESS_MAPPER_URL\" \"$WORDPRESS_MAPPER_URL\" " /config.json
 sed -i "s \"UPP_INTERNAL_ARTICLE_VALIDATOR_URL\" \"$UPP_INTERNAL_ARTICLE_VALIDATOR_URL\" " /config.json
 sed -i "s \"UPP_LIST_VALIDATOR_URL\" \"$UPP_LIST_VALIDATOR_URL\" " /config.json
+sed -i "s \"UPP_INTERNAL_CPH_VALIDATOR_URL\" \"$UPP_INTERNAL_CPH_VALIDATOR_URL\" " /config.json
 sed -i "s \"UUID_RESOLVER_URL\" \"$UUID_RESOLVER_URL\" " /config.json
 sed -i "s \"GRAPHITE_ADDRESS\" \"$GRAPHITE_ADDRESS\" " /config.json
 sed -i "s \"GRAPHITE_UUID\" \"$GRAPHITE_UUID\" " /config.json

--- a/startup.sh
+++ b/startup.sh
@@ -6,6 +6,7 @@ sed -i "s \"CONTENT_URL\" \"$CONTENT_URL\" " /config.json
 sed -i "s \"CONTENT_NEO4J_URL\" \"$CONTENT_NEO4J_URL\" " /config.json
 sed -i "s \"COMPLEMENTARY_CONTENT_URL\" \"$COMPLEMENTARY_CONTENT_URL\" " /config.json
 sed -i "s \"LISTS_URL\" \"$LISTS_URL\" " /config.json
+sed -i "s \"GENERIC_LISTS_URL\" \"$GENERIC_LISTS_URL\" " /config.json
 sed -i "s \"LISTS_NOTIFICATIONS_URL\" \"$LISTS_NOTIFICATIONS_URL\" " /config.json
 sed -i "s \"NOTIFICATIONS_URL\" \"$NOTIFICATIONS_URL\" " /config.json
 sed -i "s \"LISTS_NOTIFICATIONS_PUSH_URL\" \"$LISTS_NOTIFICATIONS_PUSH_URL\" " /config.json
@@ -21,6 +22,7 @@ sed -i "s \"METHODE_ARTICLE_INTERNAL_COMPONENTS_MAPPER_URL\" \"$METHODE_ARTICLE_
 sed -i "s \"VIDEO_MAPPER_URL\" \"$VIDEO_MAPPER_URL\" " /config.json
 sed -i "s \"WORDPRESS_MAPPER_URL\" \"$WORDPRESS_MAPPER_URL\" " /config.json
 sed -i "s \"UPP_INTERNAL_ARTICLE_VALIDATOR_URL\" \"$UPP_INTERNAL_ARTICLE_VALIDATOR_URL\" " /config.json
+sed -i "s \"UPP_LIST_VALIDATOR_URL\" \"$UPP_LIST_VALIDATOR_URL\" " /config.json
 sed -i "s \"UUID_RESOLVER_URL\" \"$UUID_RESOLVER_URL\" " /config.json
 sed -i "s \"GRAPHITE_ADDRESS\" \"$GRAPHITE_ADDRESS\" " /config.json
 sed -i "s \"GRAPHITE_UUID\" \"$GRAPHITE_UUID\" " /config.json


### PR DESCRIPTION
# Description

## What

Enable generic publishing monitoring for `application/vnd.ft-upp-article-internal`, `application/vnd.ft-upp-list` 
 and `application/vnd.ft-upp-content-placeholder-internal`.

## Why

[JIRA ticket](https://financialtimes.atlassian.net/browse/UPPSF-2082).

## Anything, in particular, you'd like to highlight to reviewers

- Enabling the monitoring for those three content types as a start because there are corresponding Methode types being monitored already in PAM (`EOM::CompoundStory`, `EOM::WebContainer` and `EOM::CompoundStory_Internal_CPH`).
- Images will be done separately because the might require some code changes.
- Any additional content types that don't have corresponding Methode types that PAM monitors will be done in a separate task.
- For anyone with more detailed knowledge of the publishing pipeline, please pay attention to the endpoints in `config.json.template` and provide feedback if there's a need to add some new endpoint or configure a type to be checked for an existing endpoint for the newly added generic content types.


## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
