### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbooks/runbook.md
+++ b/runbooks/runbook.md
@@ -1,3 +1,7 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - Publish Availability Monitor
 
 For every piece of published content, polls the relevant endpoints to ascertain whether the publish was successful, within the time limit as per SLA. The resulting metrics are fed to Splunk.
@@ -18,23 +22,6 @@ Platinum
 
 Production
 
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- dimitar.terziev
-- elitsa.pavlova
-- hristo.georgiev
-- donislav.belev
-- mihail.mihaylov
-- boyko.boykov
-
 ## Host Platform
 
 AWS
@@ -43,9 +30,9 @@ AWS
 
 The Publish Availability Monitor listens to new content messages via the Kafka topic NativeCmsPublicationEvents, and polls (or in the case of Notifications Push listens) to the following endpoints until the content appears or the content SLA times out:
 
-- The Content Public Read /content/{uuid} endpoint.
-- The Notifications /content/notifications endpoint.
-- The Notifications Push /content/notifications-push endpoint.
+*   The Content Public Read /content/{uuid} endpoint.
+*   The Notifications /content/notifications endpoint.
+*   The Notifications Push /content/notifications-push endpoint.
 
 Additionally, if the content is an image, PAM will check the S3 image bucket
 to see that the binary of the image has been saved. If two of the last ten
@@ -60,6 +47,20 @@ No
 ## Contains Sensitive Data
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -97,6 +98,14 @@ Manual
 
 The release is triggered by making a Github release which is then picked up by a Jenkins multibranch pipeline. The Jenkins pipeline should be manually started in order for it to deploy the helm package to the Kubernetes clusters.
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 NotApplicable
@@ -109,8 +118,8 @@ There is no key rotation procedure for this system.
 
 Pod health:
 
-- <https://upp-prod-publish-eu.ft.com/__health/__pods-health?service-name=publish-availability-monitor>
-- <https://upp-prod-publish-us.ft.com/__health/__pods-health?service-name=publish-availability-monitor>
+*   <https://upp-prod-publish-eu.ft.com/__health/__pods-health?service-name=publish-availability-monitor>
+*   <https://upp-prod-publish-us.ft.com/__health/__pods-health?service-name=publish-availability-monitor>
 
 ## First Line Troubleshooting
 


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/publish-availability-monitor/blob/runbook-no-relationships-2021-03-19/runbooks/runbook.md) file has been automatically regenerated from the Biz Ops data for the **publish-availability-monitor** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **publish-availability-monitor** system in [Biz Ops](https://biz-ops.in.ft.com/System/publish-availability-monitor).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
