### PR TITLE
Enable generic image, image set & graphics monitoring

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -25,7 +25,10 @@
         "video",
         "wordpress",
         "application/vnd.ft-upp-article-internal",
-        "application/vnd.ft-upp-content-placeholder-internal"
+        "application/vnd.ft-upp-content-placeholder-internal",
+        "application/vnd.ft-upp-image",
+        "application/vnd.ft-upp-image-set",
+        "application/vnd.ft-upp-graphic"
       ]
     },
     {
@@ -147,7 +150,10 @@
     "wordpress": "WORDPRESS_MAPPER_URL",
     "application/vnd.ft-upp-article-internal": "UPP_INTERNAL_ARTICLE_VALIDATOR_URL",
     "application/vnd.ft-upp-list": "UPP_LIST_VALIDATOR_URL",
-    "application/vnd.ft-upp-content-placeholder-internal": "UPP_INTERNAL_CPH_VALIDATOR_URL"
+    "application/vnd.ft-upp-content-placeholder-internal": "UPP_INTERNAL_CPH_VALIDATOR_URL",
+    "application/vnd.ft-upp-image": "UPP_IMAGE_VALIDATOR_URL",
+    "application/vnd.ft-upp-image-set": "UPP_IMAGE_SET_VALIDATOR_URL",
+    "application/vnd.ft-upp-graphic": "UPP_GRAPHIC_VALIDATOR_URL"
   },
   "uuidResolverUrl": "UUID_RESOLVER_URL",
   "capabilities": [

--- a/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_dev.yaml
+++ b/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_dev.yaml
@@ -32,6 +32,9 @@ envs:
     upp_internal_article_validator: "__upp-internal-article-validator/validate"
     upp_list_validator: "__upp-list-validator/validate"
     upp_internal_cph_validator: "__upp-internal-content-placeholder-validator/validate"
+    upp_image_validator: "__upp-image-validator/validate"
+    upp_image_set_validator: "__upp-image-set-validator/validate"
+    upp_graphic_validator: "__upp-graphic-validator/validate"
   uuid_resolver_url: "/__document-store-api"
 
 cluster:

--- a/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_prod.yaml
+++ b/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_prod.yaml
@@ -32,6 +32,9 @@ envs:
     upp_internal_article_validator: "__upp-internal-article-validator/validate"
     upp_list_validator: "__upp-list-validator/validate"
     upp_internal_cph_validator: "__upp-internal-content-placeholder-validator/validate"
+    upp_image_validator: "__upp-image-validator/validate"
+    upp_image_set_validator: "__upp-image-set-validator/validate"
+    upp_graphic_validator: "__upp-graphic-validator/validate"
   uuid_resolver_url: "/__document-store-api"
 
 cluster:

--- a/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_staging.yaml
+++ b/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_staging.yaml
@@ -32,6 +32,9 @@ envs:
     upp_internal_article_validator: "__upp-internal-article-validator/validate"
     upp_list_validator: "__upp-list-validator/validate"
     upp_internal_cph_validator: "__upp-internal-content-placeholder-validator/validate"
+    upp_image_validator: "__upp-image-validator/validate"
+    upp_image_set_validator: "__upp-image-set-validator/validate"
+    upp_graphic_validator: "__upp-graphic-validator/validate"
   uuid_resolver_url: "/__document-store-api"
 
 cluster:

--- a/helm/publish-availability-monitor/templates/deployment.yaml
+++ b/helm/publish-availability-monitor/templates/deployment.yaml
@@ -107,6 +107,12 @@ spec:
           value: "{{ $base_url }}/{{ .Values.envs.validation_endpoints.upp_list_validator }}"
         - name: UPP_INTERNAL_CPH_VALIDATOR_URL
           value: "{{ $base_url }}/{{ .Values.envs.validation_endpoints.upp_internal_cph_validator }}"
+        - name: UPP_IMAGE_VALIDATOR_URL
+          value: "{{ $base_url }}/{{ .Values.envs.validation_endpoints.upp_image_validator }}"
+        - name: UPP_IMAGE_SET_VALIDATOR_URL
+          value: "{{ $base_url }}/{{ .Values.envs.validation_endpoints.upp_image_set_validator }}"
+        - name: UPP_GRAPHIC_VALIDATOR_URL
+          value: "{{ $base_url }}/{{ .Values.envs.validation_endpoints.upp_graphic_validator }}"
         - name: UUID_RESOLVER_URL
           value: "{{ .Values.envs.uuid_resolver_url }}"
         ports:

--- a/startup.sh
+++ b/startup.sh
@@ -24,6 +24,9 @@ sed -i "s \"WORDPRESS_MAPPER_URL\" \"$WORDPRESS_MAPPER_URL\" " /config.json
 sed -i "s \"UPP_INTERNAL_ARTICLE_VALIDATOR_URL\" \"$UPP_INTERNAL_ARTICLE_VALIDATOR_URL\" " /config.json
 sed -i "s \"UPP_LIST_VALIDATOR_URL\" \"$UPP_LIST_VALIDATOR_URL\" " /config.json
 sed -i "s \"UPP_INTERNAL_CPH_VALIDATOR_URL\" \"$UPP_INTERNAL_CPH_VALIDATOR_URL\" " /config.json
+sed -i "s \"UPP_IMAGE_VALIDATOR_URL\" \"$UPP_IMAGE_VALIDATOR_URL\" " /config.json
+sed -i "s \"UPP_IMAGE_SET_VALIDATOR_URL\" \"$UPP_IMAGE_SET_VALIDATOR_URL\" " /config.json
+sed -i "s \"UPP_GRAPHIC_VALIDATOR_URL\" \"$UPP_GRAPHIC_VALIDATOR_URL\" " /config.json
 sed -i "s \"UUID_RESOLVER_URL\" \"$UUID_RESOLVER_URL\" " /config.json
 sed -i "s \"GRAPHITE_ADDRESS\" \"$GRAPHITE_ADDRESS\" " /config.json
 sed -i "s \"GRAPHITE_UUID\" \"$GRAPHITE_UUID\" " /config.json


### PR DESCRIPTION
# Description

## What

Enable generic publishing monitoring for:

- `application/vnd.ft-upp-image`
- `application/vnd.ft-upp-image-set`
-  `application/vnd.ft-upp-graphic`

## Why

[JIRA ticket](https://financialtimes.atlassian.net/browse/UPPSF-2119).

## Anything, in particular, you'd like to highlight to reviewers

Couple of points:

- I have implemented each of the three types to be validated with a separate validator service because that will be the way it will work in the near future, currently working only on Dev.
- The only endpoint that I have configured PAM to check is CONTENT_URL (i.e. `/__document-store-api/content/`) because except for the S3 endpoint (not checked for generic images) that was the only other endpoint used for the old Methode Images & ImageSets. @Financial-Times/content-team  Please advice if there are some other endpoints that PAM needs to check for any of the three content types.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
