### PR TITLE
Introduce changes which remedy SLA alerts for SV content.

### DIFF
--- a/checks/publishCheck_notificationsCheck_test.go
+++ b/checks/publishCheck_notificationsCheck_test.go
@@ -27,9 +27,11 @@ func (f testFeed) Stop()  {}
 func (f testFeed) FeedName() string {
 	return f.feedName
 }
+
 func (f testFeed) FeedType() string {
 	return f.feedType
 }
+
 func (f testFeed) FeedURL() string {
 	return f.feedName
 }
@@ -56,6 +58,7 @@ func TestFeedContainsMatchingNotification(t *testing.T) {
 	notificationsCheck := &NotificationsCheck{
 		mockHTTPCaller(t, "", nil),
 		subscribedFeeds,
+		[]string{FTPinkPublication},
 		feedName,
 	}
 	log := logger.NewUPPLogger("test", "PANIC")
@@ -85,6 +88,7 @@ func TestFeedMissingNotification(t *testing.T) {
 	notificationsCheck := &NotificationsCheck{
 		mockHTTPCaller(t, "", nil),
 		subscribedFeeds,
+		[]string{FTPinkPublication},
 		feedName,
 	}
 	log := logger.NewUPPLogger("test", "PANIC")
@@ -110,7 +114,11 @@ func TestFeedContainsEarlierNotification(t *testing.T) {
 	testTID2 := "tid_0123wxyz"
 	testLastModified2, _ := time.Parse(DateLayout, "2016-10-28T14:00:00.000Z")
 
-	n := feeds.Notification{ID: testUUID, PublishReference: testTID1, LastModified: testLastModified1}
+	n := feeds.Notification{
+		ID:               testUUID,
+		PublishReference: testTID1,
+		LastModified:     testLastModified1,
+	}
 	notifications := []*feeds.Notification{&n}
 	f := mockFeed(feedName, testUUID, notifications)
 	subscribedFeeds := make(map[string][]feeds.Feed)
@@ -119,12 +127,18 @@ func TestFeedContainsEarlierNotification(t *testing.T) {
 	notificationsCheck := &NotificationsCheck{
 		mockHTTPCaller(t, "", nil),
 		subscribedFeeds,
+		[]string{FTPinkPublication},
 		feedName,
 	}
 	log := logger.NewUPPLogger("test", "PANIC")
 
 	pc := NewPublishCheck(
-		newPublishMetricBuilder().withUUID(testUUID).withPlatform(testEnv).withTID(testTID2).withPublishDate(testLastModified2).build(),
+		newPublishMetricBuilder().withUUID(testUUID).
+			withPlatform(testEnv).
+			withTID(testTID2).
+			withPublishDate(testLastModified2).
+			withPublication([]string{FTPinkPublication}).
+			build(),
 		"",
 		"",
 		0,
@@ -145,7 +159,11 @@ func TestFeedContainsLaterNotification(t *testing.T) {
 	testTID2 := "tid_0123wxyz"
 	testLastModified2, _ := time.Parse(DateLayout, "2016-10-28T13:59:00.000Z")
 
-	n := feeds.Notification{ID: testUUID, PublishReference: testTID1, LastModified: testLastModified1}
+	n := feeds.Notification{
+		ID:               testUUID,
+		PublishReference: testTID1,
+		LastModified:     testLastModified1,
+	}
 	notifications := []*feeds.Notification{&n}
 	f := mockFeed(feedName, testUUID, notifications)
 	subscribedFeeds := make(map[string][]feeds.Feed)
@@ -154,12 +172,17 @@ func TestFeedContainsLaterNotification(t *testing.T) {
 	notificationsCheck := &NotificationsCheck{
 		mockHTTPCaller(t, "", nil),
 		subscribedFeeds,
+		[]string{FTPinkPublication},
 		feedName,
 	}
 	log := logger.NewUPPLogger("test", "PANIC")
 
 	pc := NewPublishCheck(
-		newPublishMetricBuilder().withUUID(testUUID).withPlatform(testEnv).withTID(testTID2).withPublishDate(testLastModified2).build(),
+		newPublishMetricBuilder().withUUID(testUUID).
+			withPlatform(testEnv).
+			withTID(testTID2).
+			withPublishDate(testLastModified2).
+			build(),
 		"",
 		"",
 		0,
@@ -179,7 +202,11 @@ func TestFeedContainsUnparseableNotification(t *testing.T) {
 	testTID2 := "tid_0123wxyz"
 	testLastModified2, _ := time.Parse(DateLayout, "2016-10-28T13:59:00.000Z")
 
-	n := feeds.Notification{ID: testUUID, PublishReference: testTID1, LastModified: testLastModified1}
+	n := feeds.Notification{
+		ID:               testUUID,
+		PublishReference: testTID1,
+		LastModified:     testLastModified1,
+	}
 	notifications := []*feeds.Notification{&n}
 	f := mockFeed(feedName, testUUID, notifications)
 	subscribedFeeds := make(map[string][]feeds.Feed)
@@ -188,12 +215,18 @@ func TestFeedContainsUnparseableNotification(t *testing.T) {
 	notificationsCheck := &NotificationsCheck{
 		mockHTTPCaller(t, "", nil),
 		subscribedFeeds,
+		[]string{FTPinkPublication},
 		feedName,
 	}
 	log := logger.NewUPPLogger("test", "PANIC")
 
 	pc := NewPublishCheck(
-		newPublishMetricBuilder().withUUID(testUUID).withPlatform(testEnv).withTID(testTID2).withPublishDate(testLastModified2).build(),
+		newPublishMetricBuilder().withUUID(testUUID).
+			withPlatform(testEnv).
+			withTID(testTID2).
+			withPublishDate(testLastModified2).
+			withPublication([]string{FTPinkPublication}).
+			build(),
 		"",
 		"",
 		0,
@@ -221,12 +254,17 @@ func TestMissingFeed(t *testing.T) {
 	notificationsCheck := &NotificationsCheck{
 		mockHTTPCaller(t, "", nil),
 		subscribedFeeds,
+		[]string{FTPinkPublication},
 		feedName,
 	}
 	log := logger.NewUPPLogger("test", "PANIC")
 
 	pc := NewPublishCheck(
-		newPublishMetricBuilder().withUUID(testUUID).withPlatform(testEnv).withTID(testTID).build(),
+		newPublishMetricBuilder().withUUID(testUUID).
+			withPlatform(testEnv).
+			withPublication([]string{FTPinkPublication}).
+			withTID(testTID).
+			build(),
 		"",
 		"",
 		0,
@@ -254,12 +292,17 @@ func TestMissingEnvironment(t *testing.T) {
 	notificationsCheck := &NotificationsCheck{
 		mockHTTPCaller(t, "", nil),
 		subscribedFeeds,
+		[]string{FTPinkPublication},
 		feedName,
 	}
 	log := logger.NewUPPLogger("test", "PANIC")
 
 	pc := NewPublishCheck(
-		newPublishMetricBuilder().withUUID(testUUID).withPlatform(testEnv).withTID(testTID).build(),
+		newPublishMetricBuilder().withUUID(testUUID).
+			withPlatform(testEnv).
+			withPublication([]string{FTPinkPublication}).
+			withTID(testTID).
+			build(),
 		"",
 		"",
 		0,
@@ -285,11 +328,18 @@ func TestShouldSkipCheck_ContentIsNotMarkedAsDeleted_CheckNotSkipped(t *testing.
 	}
 }
 
-func TestShouldSkipCheck_ContentIsMarkedAsDeletedPreviousNotificationsExist_CheckNotSkipped(t *testing.T) {
-	pm := newPublishMetricBuilder().withMarkedDeleted(true).withEndpoint("http://notifications-endpoint:8080/content/notifications").build()
+func TestShouldSkipCheck_ContentIsMarkedAsDeletedPreviousNotificationsExist_CheckNotSkipped(
+	t *testing.T,
+) {
+	pm := newPublishMetricBuilder().withMarkedDeleted(true).
+		withEndpoint("http://notifications-endpoint:8080/content/notifications").
+		build()
 	log := logger.NewUPPLogger("test", "PANIC")
 	pc := NewPublishCheck(pm, "", "", 0, 0, nil, nil, log)
-	response := buildResponse(200, `[{"id": "foobar", "lastModified" : "foobaz", "publishReference" : "unitTestRef" }]`)
+	response := buildResponse(
+		200,
+		`[{"id": "foobar", "lastModified" : "foobaz", "publishReference" : "unitTestRef" }]`,
+	)
 	defer response.Body.Close()
 	notificationsCheck := NotificationsCheck{
 		httpCaller: mockHTTPCaller(t, "", response),
@@ -300,8 +350,12 @@ func TestShouldSkipCheck_ContentIsMarkedAsDeletedPreviousNotificationsExist_Chec
 	}
 }
 
-func TestShouldSkipCheck_ContentIsMarkedAsDeletedPreviousNotificationsDoesNotExist_CheckSkipped(t *testing.T) {
-	pm := newPublishMetricBuilder().withMarkedDeleted(true).withEndpoint("http://notifications-endpoint:8080/content/notifications").build()
+func TestShouldSkipCheck_ContentIsMarkedAsDeletedPreviousNotificationsDoesNotExist_CheckSkipped(
+	t *testing.T,
+) {
+	pm := newPublishMetricBuilder().withMarkedDeleted(true).
+		withEndpoint("http://notifications-endpoint:8080/content/notifications").
+		build()
 	log := logger.NewUPPLogger("test", "PANIC")
 	pc := NewPublishCheck(pm, "", "", 0, 0, nil, nil, log)
 	response := buildResponse(200, `[]`)

--- a/checks/publishCheck_test.go
+++ b/checks/publishCheck_test.go
@@ -161,7 +161,9 @@ func TestIsCurrentOperationFinished_ContentCheck_MarkedDeleted_NotFinished(t *te
 	assert.False(t, finished, "operation should not have finished")
 }
 
-func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsAfterCurrentPublishDate_IgnoreCheckTrue(t *testing.T) {
+func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsAfterCurrentPublishDate_IgnoreCheckTrue(
+	t *testing.T,
+) {
 	currentTid := "tid_1234"
 	publishDate, err := time.Parse(DateLayout, "2016-01-08T14:22:06.271Z")
 	assert.Nil(t, err, "Failure in setting up test data")
@@ -189,7 +191,9 @@ func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsAfterCurrentP
 }
 
 // fails for dateLayout="2006-01-02T15:04:05.000Z"
-func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsBeforeCurrentPublishDateSpecifiedWith2Decimals_IgnoreCheckFalse(t *testing.T) {
+func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsBeforeCurrentPublishDateSpecifiedWith2Decimals_IgnoreCheckFalse(
+	t *testing.T,
+) {
 	currentTid := "tid_1234"
 
 	publishDate, err := time.Parse(DateLayout, "2016-02-01T14:30:21.55Z")
@@ -217,7 +221,9 @@ func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsBeforeCurrent
 	assert.False(t, ignoreCheck, "check should not be ignored")
 }
 
-func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsBeforeCurrentPublishDate_IgnoreCheckFalse(t *testing.T) {
+func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsBeforeCurrentPublishDate_IgnoreCheckFalse(
+	t *testing.T,
+) {
 	currentTid := "tid_1234"
 	publishDate, err := time.Parse(DateLayout, "2016-01-08T14:22:06.271Z")
 	assert.Nil(t, err, "Failure in setting up test data")
@@ -244,7 +250,9 @@ func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsBeforeCurrent
 	assert.False(t, ignoreCheck, "check should not be ignored")
 }
 
-func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsBeforeCurrentPublishDate_NotFinished(t *testing.T) {
+func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsBeforeCurrentPublishDate_NotFinished(
+	t *testing.T,
+) {
 	currentTid := "tid_1234"
 	publishDate, err := time.Parse(DateLayout, "2016-01-08T14:22:06.271Z")
 	assert.Nil(t, err, "Failure in setting up test data")
@@ -271,13 +279,19 @@ func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsBeforeCurrent
 	assert.False(t, finished, "operation should not have finished")
 }
 
-func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateEqualsCurrentPublishDate_Finished(t *testing.T) {
+func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateEqualsCurrentPublishDate_Finished(
+	t *testing.T,
+) {
 	currentTid := "tid_1234"
 	publishDateAsString := "2016-01-08T14:22:06.271Z"
 	publishDate, err := time.Parse(DateLayout, publishDateAsString)
 	assert.Nil(t, err, "Failure in setting up test data")
 
-	testResponse := fmt.Sprintf(`{ "uuid" : "1234-1234", "publishReference" : "%s", "lastModified" : "%s" }`, currentTid, publishDateAsString)
+	testResponse := fmt.Sprintf(
+		`{ "uuid" : "1234-1234", "publishReference" : "%s", "lastModified" : "%s" }`,
+		currentTid,
+		publishDateAsString,
+	)
 	response := buildResponse(200, testResponse)
 	defer response.Body.Close()
 	contentCheck := &ContentCheck{
@@ -300,12 +314,17 @@ func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateEqualsCurrentPu
 }
 
 // fallback to publish reference check if last modified date is not valid
-func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsNullCurrentTIDAndPubReferenceMatch_Finished(t *testing.T) {
+func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsNullCurrentTIDAndPubReferenceMatch_Finished(
+	t *testing.T,
+) {
 	currentTid := "tid_1234"
 	publishDate, err := time.Parse(DateLayout, "2016-01-08T14:22:06.271Z")
 	assert.Nil(t, err, "Failure in setting up test data")
 
-	testResponse := fmt.Sprintf(`{ "uuid" : "1234-1234", "publishReference" : "%s", "lastModified" : null }`, currentTid)
+	testResponse := fmt.Sprintf(
+		`{ "uuid" : "1234-1234", "publishReference" : "%s", "lastModified" : null }`,
+		currentTid,
+	)
 	response := buildResponse(200, testResponse)
 	defer response.Body.Close()
 	contentCheck := &ContentCheck{
@@ -328,12 +347,17 @@ func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsNullCurrentTI
 }
 
 // fallback to publish reference check if last modified date is not valid
-func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsEmptyStringCurrentTIDAndPubReferenceMatch_Finished(t *testing.T) {
+func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsEmptyStringCurrentTIDAndPubReferenceMatch_Finished(
+	t *testing.T,
+) {
 	currentTid := "tid_1234"
 	publishDate, err := time.Parse(DateLayout, "2016-01-08T14:22:06.271Z")
 	assert.Nil(t, err, "Failure in setting up test data")
 
-	testResponse := fmt.Sprintf(`{ "uuid" : "1234-1234", "publishReference" : "%s", "lastModified" : "" }`, currentTid)
+	testResponse := fmt.Sprintf(
+		`{ "uuid" : "1234-1234", "publishReference" : "%s", "lastModified" : "" }`,
+		currentTid,
+	)
 	response := buildResponse(200, testResponse)
 	defer response.Body.Close()
 	contentCheck := &ContentCheck{
@@ -353,10 +377,67 @@ func TestIsCurrentOperationFinished_ContentCheck_LastModifiedDateIsEmptyStringCu
 		log,
 	))
 	assert.True(t, finished, "operation should have finished successfully")
+}
+
+func TestIsCurrentOperationFinished_PushNotifications_EditorialDesk_Ignored(t *testing.T) {
+	testResponse := `[]`
+
+	response := buildResponse(200, testResponse)
+	defer response.Body.Close()
+
+	notificationCheck := &NotificationsCheck{
+		feedName:   "notifications-push",
+		httpCaller: mockHTTPCaller(t, "tid_pam_1234", response),
+	}
+
+	log := logger.NewUPPLogger("test", "PANIC")
+
+	pm := newPublishMetricBuilder().withEditorialDesk(CentralBankingEditorialDesk).build()
+	_, ignoreCheck := notificationCheck.isCurrentOperationFinished(NewPublishCheck(
+		pm,
+		"",
+		"",
+		0,
+		0,
+		nil,
+		nil,
+		log,
+	))
+	assert.True(t, ignoreCheck, "check should be ignored")
+}
+
+func TestIsCurrentOperationFinished_PushNotifications_Publication_Ignored(t *testing.T) {
+	testResponse := `[]`
+
+	response := buildResponse(200, testResponse)
+	defer response.Body.Close()
+
+	notificationCheck := &NotificationsCheck{
+		feedName:   "notifications-push",
+		httpCaller: mockHTTPCaller(t, "tid_pam_1234", response),
+	}
+
+	log := logger.NewUPPLogger("test", "PANIC")
+
+	pm := newPublishMetricBuilder().withPublication([]string{SustainableViewsPublication}).
+		build()
+	_, ignoreCheck := notificationCheck.isCurrentOperationFinished(NewPublishCheck(
+		pm,
+		"",
+		"",
+		0,
+		0,
+		nil,
+		nil,
+		log,
+	))
+	assert.True(t, ignoreCheck, "check should be ignored")
 }
 
 type publishMetricBuilder interface {
 	withUUID(string) publishMetricBuilder
+	withEditorialDesk(string) publishMetricBuilder
+	withPublication([]string) publishMetricBuilder
 	withEndpoint(string) publishMetricBuilder
 	withPlatform(string) publishMetricBuilder
 	withTID(string) publishMetricBuilder
@@ -368,6 +449,8 @@ type publishMetricBuilder interface {
 // PublishMetricBuilder implementation
 type pmBuilder struct {
 	UUID          string
+	EditorialDesk string
+	Publication   []string
 	endpoint      url.URL
 	platform      string
 	tid           string
@@ -377,6 +460,16 @@ type pmBuilder struct {
 
 func (b *pmBuilder) withUUID(uuid string) publishMetricBuilder {
 	b.UUID = uuid
+	return b
+}
+
+func (b *pmBuilder) withEditorialDesk(editorialDesk string) publishMetricBuilder {
+	b.EditorialDesk = editorialDesk
+	return b
+}
+
+func (b *pmBuilder) withPublication(publication []string) publishMetricBuilder {
+	b.Publication = publication
 	return b
 }
 
@@ -410,6 +503,8 @@ func (b *pmBuilder) build() metrics.PublishMetric {
 	return metrics.PublishMetric{
 		UUID:            b.UUID,
 		Endpoint:        b.endpoint,
+		EditorialDesk:   b.EditorialDesk,
+		Publication:     b.Publication,
 		Platform:        b.platform,
 		TID:             b.tid,
 		IsMarkedDeleted: b.markedDeleted,
@@ -459,6 +554,18 @@ func mockHTTPCaller(t *testing.T, tid string, responses ...*http.Response) httpc
 }
 
 // builds testHTTPCaller with the given mocked responses in the provided order
-func mockAuthenticatedHTTPCaller(t *testing.T, tid string, username string, password string, responses ...*http.Response) httpcaller.Caller {
-	return &testHTTPCaller{t: t, tid: tid, authUser: username, authPass: password, mockResponses: responses}
+func mockAuthenticatedHTTPCaller(
+	t *testing.T,
+	tid string,
+	username string,
+	password string,
+	responses ...*http.Response,
+) httpcaller.Caller {
+	return &testHTTPCaller{
+		t:             t,
+		tid:           tid,
+		authUser:      username,
+		authPass:      password,
+		mockResponses: responses,
+	}
 }

--- a/config.json.template
+++ b/config.json.template
@@ -7,6 +7,7 @@
     "lagTolerance": "KAFKA_LAG_TOLERANCE",
     "topic": "KAFKA_TOPIC"
   },
+  "notificationsPushPublicationMonitorList": "NOTIFICATIONS_PUSH_PUBLICATION_MONITOR_LIST",
   "metricConfig": [
     {
       "endpoint": "CONTENT_URL",

--- a/config/config.go
+++ b/config/config.go
@@ -10,16 +10,17 @@ import (
 
 // AppConfig holds the application's configuration
 type AppConfig struct {
-	Threshold           int               `json:"threshold"` //pub SLA in seconds, ex. 120
-	QueueConf           QueueConfig       `json:"queueConfig"`
-	MetricConf          []MetricConfig    `json:"metricConfig"`
-	SplunkConf          SplunkConfig      `json:"splunk-config"`
-	HealthConf          HealthConfig      `json:"healthConfig"`
-	ValidationEndpoints map[string]string `json:"validationEndpoints"` //contentType to validation endpoint mapping
-	Capabilities        []Capability      `json:"capabilities"`
-	GraphiteAddress     string            `json:"graphiteAddress"`
-	GraphiteUUID        string            `json:"graphiteUUID"`
-	Environment         string            `json:"environment"`
+	Threshold                               int               `json:"threshold"` // pub SLA in seconds, ex. 120
+	QueueConf                               QueueConfig       `json:"queueConfig"`
+	MetricConf                              []MetricConfig    `json:"metricConfig"`
+	SplunkConf                              SplunkConfig      `json:"splunk-config"`
+	HealthConf                              HealthConfig      `json:"healthConfig"`
+	ValidationEndpoints                     map[string]string `json:"validationEndpoints"` // contentType to validation endpoint mapping
+	Capabilities                            []Capability      `json:"capabilities"`
+	GraphiteAddress                         string            `json:"graphiteAddress"`
+	GraphiteUUID                            string            `json:"graphiteUUID"`
+	Environment                             string            `json:"environment"`
+	NotificationsPushPublicationMonitorList string            `json:"notificationsPushPublicationMonitorList"`
 }
 
 // QueueConfig is the configuration for kafka consumer queue
@@ -33,9 +34,9 @@ type QueueConfig struct {
 
 // MetricConfig is the configuration of a PublishMetric
 type MetricConfig struct {
-	Granularity  int      `json:"granularity"` //how we split up the threshold, ex. 120/12
+	Granularity  int      `json:"granularity"` // how we split up the threshold, ex. 120/12
 	Endpoint     string   `json:"endpoint"`
-	ContentTypes []string `json:"contentTypes"` //list of valid types for this metric
+	ContentTypes []string `json:"contentTypes"` // list of valid types for this metric
 	Alias        string   `json:"alias"`
 	Health       string   `json:"health,omitempty"`
 	APIKey       string   `json:"apiKey,omitempty"`

--- a/content/genericContent.go
+++ b/content/genericContent.go
@@ -8,10 +8,12 @@ import (
 )
 
 type GenericContent struct {
-	UUID          string `json:"uuid"`
-	Type          string `json:"-"` //This field is for internal application usage
-	BinaryContent []byte `json:"-"` //This field is for internal application usage
-	Deleted       bool   `json:"deleted,omitempty"`
+	UUID          string   `json:"uuid"`
+	EditorialDesk string   `json:"editorialDesk,omitempty"`
+	Publication   []string `json:"publication,omitempty"`
+	Type          string   `json:"-"` // This field is for internal application usage
+	BinaryContent []byte   `json:"-"` // This field is for internal application usage
+	Deleted       bool     `json:"deleted,omitempty"`
 }
 
 func (gc GenericContent) Initialize(binaryContent []byte) Content {
@@ -19,7 +21,10 @@ func (gc GenericContent) Initialize(binaryContent []byte) Content {
 	return gc
 }
 
-func (gc GenericContent) Validate(externalValidationEndpoint, tid, username, password string, log *logger.UPPLogger) ValidationResponse {
+func (gc GenericContent) Validate(
+	externalValidationEndpoint, tid, username, password string,
+	log *logger.UPPLogger,
+) ValidationResponse {
 	if uuidutils.ValidateUUID(gc.GetUUID()) != nil {
 		log.WithUUID(gc.GetUUID()).Warn("Generic content UUID is invalid")
 		return ValidationResponse{IsValid: false, IsMarkedDeleted: gc.isMarkedDeleted()}
@@ -50,6 +55,14 @@ func (gc GenericContent) GetType() string {
 
 func (gc GenericContent) GetUUID() string {
 	return gc.UUID
+}
+
+func (gc GenericContent) GetEditorialDesk() string {
+	return gc.EditorialDesk
+}
+
+func (gc GenericContent) GetPublication() []string {
+	return gc.Publication
 }
 
 func (gc GenericContent) isValid(status int) bool {

--- a/content/genericContent_test.go
+++ b/content/genericContent_test.go
@@ -31,6 +31,7 @@ func TestGenericContent_Validate(t *testing.T) {
 					"firstPublishedDate": "2014-12-22T20:45:54.000Z",
 					"bodyXML": "<body>Lorem ipsum</body>",
 					"editorialDesk": "some string editorial desk identifier",
+					"publication"" ["8e6c705e-1132-42a2-8db0-c295e29e8658"],
 					"description": "Some descriptive explanation for this content",
 					"mainImage": "0000aa3c-0056-506b-2b73-ed90e21b3e64",
 					"someUnknownProperty" : " is totally fine, we don't validate for unknown fields/properties",
@@ -38,7 +39,10 @@ func TestGenericContent_Validate(t *testing.T) {
 				  }`),
 			},
 			ExternalValidationResponseCode: http.StatusOK,
-			Expected:                       ValidationResponse{IsValid: true, IsMarkedDeleted: false},
+			Expected: ValidationResponse{
+				IsValid:         true,
+				IsMarkedDeleted: false,
+			},
 		},
 		"valid deleted generic content": {
 			Content: GenericContent{
@@ -53,14 +57,20 @@ func TestGenericContent_Validate(t *testing.T) {
 				  }`),
 			},
 			ExternalValidationResponseCode: http.StatusOK,
-			Expected:                       ValidationResponse{IsValid: true, IsMarkedDeleted: true},
+			Expected: ValidationResponse{
+				IsValid:         true,
+				IsMarkedDeleted: true,
+			},
 		},
 		"generic content with missing uuid is invalid": {
 			Content: GenericContent{
 				UUID: "",
 			},
 			ExternalValidationResponseCode: http.StatusOK,
-			Expected:                       ValidationResponse{IsValid: false, IsMarkedDeleted: false},
+			Expected: ValidationResponse{
+				IsValid:         false,
+				IsMarkedDeleted: false,
+			},
 		},
 		"generic content with invalid uuid is invalid": {
 			Content: GenericContent{
@@ -75,7 +85,10 @@ func TestGenericContent_Validate(t *testing.T) {
 				BinaryContent: []byte(`invalid payload`),
 			},
 			ExternalValidationResponseCode: http.StatusUnsupportedMediaType,
-			Expected:                       ValidationResponse{IsValid: false, IsMarkedDeleted: false},
+			Expected: ValidationResponse{
+				IsValid:         false,
+				IsMarkedDeleted: false,
+			},
 		},
 	}
 
@@ -84,21 +97,29 @@ func TestGenericContent_Validate(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			tid := "tid_1234"
-			testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				assert.Equal(t, "/validate", req.RequestURI)
-				assert.Equal(t, httpcaller.ConstructPamTID(tid), req.Header.Get("X-Request-Id"))
-				assert.Equal(t, "POST", req.Method)
-				assert.Equal(t, test.Content.Type, req.Header.Get("Content-Type"))
+			testServer := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					assert.Equal(t, "/validate", req.RequestURI)
+					assert.Equal(t, httpcaller.ConstructPamTID(tid), req.Header.Get("X-Request-Id"))
+					assert.Equal(t, "POST", req.Method)
+					assert.Equal(t, test.Content.Type, req.Header.Get("Content-Type"))
 
-				reqBody, err := io.ReadAll(req.Body)
-				assert.NoError(t, err)
-				defer req.Body.Close()
+					reqBody, err := io.ReadAll(req.Body)
+					assert.NoError(t, err)
+					defer req.Body.Close()
 
-				assert.Equal(t, test.Content.BinaryContent, reqBody)
-				w.WriteHeader(test.ExternalValidationResponseCode)
-			}))
+					assert.Equal(t, test.Content.BinaryContent, reqBody)
+					w.WriteHeader(test.ExternalValidationResponseCode)
+				}),
+			)
 
-			validationResponse := test.Content.Validate(testServer.URL+"/validate", tid, "", "", log)
+			validationResponse := test.Content.Validate(
+				testServer.URL+"/validate",
+				tid,
+				"",
+				"",
+				log,
+			)
 			assert.Equal(t, test.Content.isMarkedDeleted(), validationResponse.IsMarkedDeleted)
 			assert.Equal(t, test.Expected, validationResponse)
 		})

--- a/content/video.go
+++ b/content/video.go
@@ -10,9 +10,11 @@ import (
 const videoType = "video"
 
 type Video struct {
-	ID            string `json:"id"`
-	Deleted       bool   `json:"deleted,omitempty"`
-	BinaryContent []byte `json:"-"` //This field is for internal application usage
+	ID            string   `json:"id"`
+	Deleted       bool     `json:"deleted,omitempty"`
+	EditorialDesk string   `json:"editorialDesk,omitempty"`
+	Publication   []string `json:"publication,omitempty"`
+	BinaryContent []byte   `json:"-"` // This field is for internal application usage
 }
 
 func (video Video) Initialize(binaryContent []byte) Content {
@@ -20,7 +22,10 @@ func (video Video) Initialize(binaryContent []byte) Content {
 	return video
 }
 
-func (video Video) Validate(externalValidationEndpoint, tid, username, password string, log *logger.UPPLogger) ValidationResponse {
+func (video Video) Validate(
+	externalValidationEndpoint, tid, username, password string,
+	log *logger.UPPLogger,
+) ValidationResponse {
 	uuid := video.GetUUID()
 
 	if uuidutils.ValidateUUID(uuid) != nil {
@@ -60,4 +65,12 @@ func (video Video) GetType() string {
 
 func (video Video) GetUUID() string {
 	return video.ID
+}
+
+func (video Video) GetEditorialDesk() string {
+	return video.EditorialDesk
+}
+
+func (video Video) GetPublication() []string {
+	return video.Publication
 }

--- a/content/video_test.go
+++ b/content/video_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestIsVideoValid_Valid(t *testing.T) {
-	var videoValid = Video{
+	videoValid := Video{
 		ID:            "e28b12f7-9796-3331-b030-05082f0b8157",
 		BinaryContent: []byte("valid-json"),
 	}
@@ -20,15 +20,17 @@ func TestIsVideoValid_Valid(t *testing.T) {
 	tid := "tid_1234"
 	pamTID := httpcaller.ConstructPamTID(tid)
 
-	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		assert.Equal(t, "/map", req.RequestURI)
-		assert.Equal(t, pamTID, req.Header.Get("X-Request-Id"))
+	testServer := httptest.NewServer(
+		http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+			assert.Equal(t, "/map", req.RequestURI)
+			assert.Equal(t, pamTID, req.Header.Get("X-Request-Id"))
 
-		defer req.Body.Close()
-		reqBody, err := io.ReadAll(req.Body)
-		assert.NoError(t, err)
-		assert.Equal(t, videoValid.BinaryContent, reqBody)
-	}))
+			defer req.Body.Close()
+			reqBody, err := io.ReadAll(req.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, videoValid.BinaryContent, reqBody)
+		}),
+	)
 
 	log := logger.NewUPPLogger("test", "PANIC")
 
@@ -37,7 +39,7 @@ func TestIsVideoValid_Valid(t *testing.T) {
 }
 
 func TestIsVideoValid_NoId(t *testing.T) {
-	var videoNoID = Video{}
+	videoNoID := Video{}
 	log := logger.NewUPPLogger("test", "PANIC")
 
 	validationResponse := videoNoID.Validate("", "", "", "", log)
@@ -45,7 +47,7 @@ func TestIsVideoValid_NoId(t *testing.T) {
 }
 
 func TestIsVideoValid_failedExternalValidation(t *testing.T) {
-	var videoInvalid = Video{
+	videoInvalid := Video{
 		ID:            "e28b12f7-9796-3331-b030-05082f0b8157",
 		BinaryContent: []byte("invalid-json"),
 	}
@@ -53,17 +55,19 @@ func TestIsVideoValid_failedExternalValidation(t *testing.T) {
 	tid := "tid_1234"
 	pamTID := httpcaller.ConstructPamTID(tid)
 
-	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		assert.Equal(t, "/map", req.RequestURI)
-		assert.Equal(t, pamTID, req.Header.Get("X-Request-Id"))
+	testServer := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			assert.Equal(t, "/map", req.RequestURI)
+			assert.Equal(t, pamTID, req.Header.Get("X-Request-Id"))
 
-		defer req.Body.Close()
-		reqBody, err := io.ReadAll(req.Body)
-		assert.NoError(t, err)
-		assert.Equal(t, videoInvalid.BinaryContent, reqBody)
+			defer req.Body.Close()
+			reqBody, err := io.ReadAll(req.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, videoInvalid.BinaryContent, reqBody)
 
-		w.WriteHeader(http.StatusBadRequest)
-	}))
+			w.WriteHeader(http.StatusBadRequest)
+		}),
+	)
 
 	log := logger.NewUPPLogger("test", "PANIC")
 	validationResponse := videoInvalid.Validate(testServer.URL+"/map", tid, "", "", log)
@@ -71,7 +75,7 @@ func TestIsVideoValid_failedExternalValidation(t *testing.T) {
 }
 
 func TestIsDeleted(t *testing.T) {
-	var videoNoDates = Video{
+	videoNoDates := Video{
 		ID:      "e28b12f7-9796-3331-b030-05082f0b8157",
 		Deleted: true,
 	}

--- a/feeds/notificationsPullFeed.go
+++ b/feeds/notificationsPullFeed.go
@@ -73,7 +73,10 @@ func (f *NotificationsPullFeed) pollNotificationsFeed() {
 		URL:      notificationsURL,
 		Username: f.username,
 		Password: f.password,
-		TID:      tid,
+		XPolicies: []string{
+			"PBLC_READ_8e6c705e-1132-42a2-8db0-c295e29e8658,PBLC_READ_88fdde6c-2aa4-4f78-af02-9f680097cfd6",
+		},
+		TID: tid,
 	})
 	if err != nil {
 		log.WithError(err).Errorf("error calling notifications %s", notificationsURL)

--- a/helm/publish-availability-monitor/templates/deployment.yaml
+++ b/helm/publish-availability-monitor/templates/deployment.yaml
@@ -70,6 +70,8 @@ spec:
           value: "{{ .Values.envs.lists_url }}"
         - name: PAGES_URL
           value: "{{ .Values.envs.pages_url }}"
+        - name: NOTIFICATIONS_PUSH_PUBLICATION_MONITOR_LIST
+          value: {{ .Values.envs.notifications_push_publication_monitor_list }}
         - name: NOTIFICATIONS_URL
           value: {{ .Values.envs.notifications_url }}\&{{ .Values.envs.notifications_url_param2 }}
         - name: NOTIFICATIONS_PUSH_URL

--- a/helm/publish-availability-monitor/values.yaml
+++ b/helm/publish-availability-monitor/values.yaml
@@ -26,6 +26,7 @@ envs:
     video_mapper_endpoint: ""
     base_url: ""
   graphite_address: "graphitev2.ft.com:2003"
+  notifications_push_publication_monitor_list: "88fdde6c-2aa4-4f78-af02-9f680097cfd6"
 volumes:
   read_envs_config_mount_path: "/etc/pam/envs"
   secrets_mount_path: "/etc/pam/credentials"

--- a/main.go
+++ b/main.go
@@ -22,10 +22,30 @@ import (
 )
 
 var configFileName = flag.String("config", "", "Path to configuration file")
-var envsFileName = flag.String("envs-file-name", "/etc/pam/envs/read-environments.json", "Path to json file that contains environments configuration")
-var envCredentialsFileName = flag.String("envs-credentials-file-name", "/etc/pam/credentials/read-environments-credentials.json", "Path to json file that contains environments credentials")
-var validatorCredentialsFileName = flag.String("validator-credentials-file-name", "/etc/pam/credentials/validator-credentials.json", "Path to json file that contains validation endpoints configuration")
-var configRefreshPeriod = flag.Int("config-refresh-period", 1, "Refresh period for configuration in minutes. By default it is 1 minute.")
+
+var envsFileName = flag.String(
+	"envs-file-name",
+	"/etc/pam/envs/read-environments.json",
+	"Path to json file that contains environments configuration",
+)
+
+var envCredentialsFileName = flag.String(
+	"envs-credentials-file-name",
+	"/etc/pam/credentials/read-environments-credentials.json",
+	"Path to json file that contains environments credentials",
+)
+
+var validatorCredentialsFileName = flag.String(
+	"validator-credentials-file-name",
+	"/etc/pam/credentials/validator-credentials.json",
+	"Path to json file that contains validation endpoints configuration",
+)
+
+var configRefreshPeriod = flag.Int(
+	"config-refresh-period",
+	1,
+	"Refresh period for configuration in minutes. By default it is 1 minute.",
+)
 
 var carouselTransactionIDRegExp = regexp.MustCompile(`^.+_carousel_[\d]{10}.*$`)
 
@@ -41,10 +61,10 @@ func main() {
 		return
 	}
 
-	var environments = envs.NewEnvironments()
-	var subscribedFeeds = make(map[string][]feeds.Feed)
-	var metricSink = make(chan metrics.PublishMetric)
-	var configFilesHashValues = make(map[string]string)
+	environments := envs.NewEnvironments()
+	subscribedFeeds := make(map[string][]feeds.Feed)
+	metricSink := make(chan metrics.PublishMetric)
+	configFilesHashValues := make(map[string]string)
 
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
@@ -82,7 +102,15 @@ func main() {
 		arn = &appConfig.QueueConf.ClusterARN
 	}
 
-	messageHandler := NewKafkaMessageHandler(appConfig, environments, subscribedFeeds, metricSink, metricContainer, e2eTestUUIDs, log)
+	messageHandler := NewKafkaMessageHandler(
+		appConfig,
+		environments,
+		subscribedFeeds,
+		metricSink,
+		metricContainer,
+		e2eTestUUIDs,
+		log,
+	)
 	consumer, err := kafka.NewConsumer(
 		kafka.ConsumerConfig{
 			ClusterArn:              arn,
@@ -91,7 +119,10 @@ func main() {
 			Options:                 kafka.DefaultConsumerOptions(),
 		},
 		[]*kafka.Topic{
-			kafka.NewTopic(appConfig.QueueConf.Topic, kafka.WithLagTolerance(int64(appConfig.QueueConf.LagTolerance))),
+			kafka.NewTopic(
+				appConfig.QueueConf.Topic,
+				kafka.WithLagTolerance(int64(appConfig.QueueConf.LagTolerance)),
+			),
 		},
 		log,
 	)
@@ -109,7 +140,12 @@ func main() {
 		metrics.NewGraphiteSender(appConfig, log),
 	}
 
-	aggregator := metrics.NewAggregator(metricSink, publishMetricDestinations, capabilityMetricDestinations, log)
+	aggregator := metrics.NewAggregator(
+		metricSink,
+		publishMetricDestinations,
+		capabilityMetricDestinations,
+		log,
+	)
 	go aggregator.Run()
 
 	for !environments.AreReady() {

--- a/messageHandler_integration_test.go
+++ b/messageHandler_integration_test.go
@@ -22,9 +22,11 @@ import (
 
 func TestHandleMessage_ProducesMetrics(t *testing.T) {
 	log := logger.NewUPPLogger("publish-availability-monitor", "INFO")
-	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
+	testServer := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
 
 	tests := map[string]struct {
 		AppConfig            *config.AppConfig
@@ -52,6 +54,7 @@ func TestHandleMessage_ProducesMetrics(t *testing.T) {
 						MetricAlias: "notifications-push",
 					},
 				},
+				NotificationsPushPublicationMonitorList: "88fdde6c-2aa4-4f78-af02-9f680097cfd6",
 			},
 			E2ETestUUIDs: []string{"077f5ac2-0491-420e-a5d0-982e0f86204b"},
 			KafkaMessage: kafka.FTMessage{
@@ -66,8 +69,11 @@ func TestHandleMessage_ProducesMetrics(t *testing.T) {
 					"type": "Article"
 				}`,
 			},
-			NotificationsPayload: getNotificationsPayload("077f5ac2-0491-420e-a5d0-982e0f86204b", "SYNTHETIC-REQ-MON077f5ac2-0491-420e-a5d0-982e0f86204b"),
-			IsMetricExpected:     true,
+			NotificationsPayload: getNotificationsPayload(
+				"077f5ac2-0491-420e-a5d0-982e0f86204b",
+				"SYNTHETIC-REQ-MON077f5ac2-0491-420e-a5d0-982e0f86204b",
+			),
+			IsMetricExpected: true,
 			ExpectedMetric: metrics.PublishMetric{
 				TID:       "SYNTHETIC-REQ-MON077f5ac2-0491-420e-a5d0-982e0f86204b",
 				PublishOK: true,
@@ -86,6 +92,7 @@ func TestHandleMessage_ProducesMetrics(t *testing.T) {
 						Alias:       "notifications-push",
 					},
 				},
+				NotificationsPushPublicationMonitorList: "88fdde6c-2aa4-4f78-af02-9f680097cfd6",
 			},
 			KafkaMessage: kafka.FTMessage{
 				Headers: map[string]string{
@@ -96,7 +103,8 @@ func TestHandleMessage_ProducesMetrics(t *testing.T) {
 				},
 				Body: `{
 					"uuid": "077f5ac2-0491-420e-a5d0-982e0f86204b",
-					"type": "Article"
+					"type": "Article",
+					"publication": ["88fdde6c-2aa4-4f78-af02-9f680097cfd6"]
 				}`,
 			},
 			IsMetricExpected: false,
@@ -111,6 +119,7 @@ func TestHandleMessage_ProducesMetrics(t *testing.T) {
 						Alias:       "notifications-push",
 					},
 				},
+				NotificationsPushPublicationMonitorList: "88fdde6c-2aa4-4f78-af02-9f680097cfd6",
 			},
 			KafkaMessage: kafka.FTMessage{
 				Headers: map[string]string{
@@ -121,7 +130,8 @@ func TestHandleMessage_ProducesMetrics(t *testing.T) {
 				},
 				Body: `{
 					"uuid": "077f5ac2-0491-420e-a5d0-982e0f86204b",
-					"type": "Article"
+					"type": "Article",
+					"publication": ["88fdde6c-2aa4-4f78-af02-9f680097cfd6"]
 				}`,
 			},
 			IsMetricExpected: false,
@@ -139,6 +149,7 @@ func TestHandleMessage_ProducesMetrics(t *testing.T) {
 						Alias:       "notifications-push",
 					},
 				},
+				NotificationsPushPublicationMonitorList: "88fdde6c-2aa4-4f78-af02-9f680097cfd6",
 			},
 			KafkaMessage: kafka.FTMessage{
 				Headers: map[string]string{
@@ -149,7 +160,8 @@ func TestHandleMessage_ProducesMetrics(t *testing.T) {
 				},
 				Body: `{
 					"uuid": "077f5ac2-0491-420e-a5d0-982e0f86204b",
-					"type": "Article"
+					"type": "Article",
+					"publication": ["88fdde6c-2aa4-4f78-af02-9f680097cfd6"]
 				}`,
 			},
 			IsMetricExpected: false,
@@ -168,6 +180,7 @@ func TestHandleMessage_ProducesMetrics(t *testing.T) {
 						ContentTypes: []string{"application/vnd.ft-upp-article-internal+json"},
 					},
 				},
+				NotificationsPushPublicationMonitorList: "88fdde6c-2aa4-4f78-af02-9f680097cfd6",
 			},
 			KafkaMessage: kafka.FTMessage{
 				Headers: map[string]string{
@@ -178,7 +191,8 @@ func TestHandleMessage_ProducesMetrics(t *testing.T) {
 				},
 				Body: `{
 					"uuid": "077f5ac2-0491-420e-a5d0-982e0f86204b",
-					"type": "Article"
+					"type": "Article",
+					"publication": ["88fdde6c-2aa4-4f78-af02-9f680097cfd6"]
 				}`,
 			},
 			IsMetricExpected: true,
@@ -201,6 +215,7 @@ func TestHandleMessage_ProducesMetrics(t *testing.T) {
 						ContentTypes: []string{"application/vnd.ft-upp-article-internal+json"},
 					},
 				},
+				NotificationsPushPublicationMonitorList: "88fdde6c-2aa4-4f78-af02-9f680097cfd6",
 			},
 			KafkaMessage: kafka.FTMessage{
 				Headers: map[string]string{
@@ -211,11 +226,15 @@ func TestHandleMessage_ProducesMetrics(t *testing.T) {
 				},
 				Body: `{
 					"uuid": "077f5ac2-0491-420e-a5d0-982e0f86204b",
-					"type": "Article"
+					"type": "Article",
+					"publication": ["88fdde6c-2aa4-4f78-af02-9f680097cfd6"]
 				}`,
 			},
-			NotificationsPayload: getNotificationsPayload("077f5ac2-0491-420e-a5d0-982e0f86204b", "tid_077f5ac2-0491-420e-a5d0-982e0f86204b"),
-			IsMetricExpected:     true,
+			NotificationsPayload: getNotificationsPayload(
+				"077f5ac2-0491-420e-a5d0-982e0f86204b",
+				"tid_077f5ac2-0491-420e-a5d0-982e0f86204b",
+			),
+			IsMetricExpected: true,
 			ExpectedMetric: metrics.PublishMetric{
 				TID:       "tid_077f5ac2-0491-420e-a5d0-982e0f86204b",
 				PublishOK: true,
@@ -227,7 +246,7 @@ func TestHandleMessage_ProducesMetrics(t *testing.T) {
 		test := test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			var testEnvs = envs.NewEnvironments()
+			testEnvs := envs.NewEnvironments()
 			testEnvs.SetEnvironment("env1", envs.Environment{
 				Name:    "env1",
 				ReadURL: "http://env1.example.org",
@@ -246,10 +265,18 @@ func TestHandleMessage_ProducesMetrics(t *testing.T) {
 			subscribedFeeds := map[string][]feeds.Feed{}
 			subscribedFeeds["env1"] = append(subscribedFeeds["env1"], f)
 
-			var metricsCh = make(chan metrics.PublishMetric)
-			var metricsHistory = metrics.NewHistory(make([]metrics.PublishMetric, 0))
+			metricsCh := make(chan metrics.PublishMetric)
+			metricsHistory := metrics.NewHistory(make([]metrics.PublishMetric, 0))
 
-			mh := NewKafkaMessageHandler(test.AppConfig, testEnvs, subscribedFeeds, metricsCh, metricsHistory, test.E2ETestUUIDs, log)
+			mh := NewKafkaMessageHandler(
+				test.AppConfig,
+				testEnvs,
+				subscribedFeeds,
+				metricsCh,
+				metricsHistory,
+				test.E2ETestUUIDs,
+				log,
+			)
 			kmh := mh.(*kafkaMessageHandler)
 
 			kmh.HandleMessage(test.KafkaMessage)
@@ -269,7 +296,11 @@ func TestHandleMessage_ProducesMetrics(t *testing.T) {
 			}
 
 			if metric.PublishOK != test.ExpectedMetric.PublishOK {
-				t.Fatalf("expected PublishOK %v, got %v", test.ExpectedMetric.PublishOK, metric.PublishOK)
+				t.Fatalf(
+					"expected PublishOK %v, got %v",
+					test.ExpectedMetric.PublishOK,
+					metric.PublishOK,
+				)
 			}
 		})
 	}
@@ -287,7 +318,10 @@ func getNotificationsPayload(uuid, tID string) string {
 	return strings.Replace(notifications, "\n", "", -1)
 }
 
-func waitForMetric(metricsCh chan metrics.PublishMetric, timeout time.Duration) (metrics.PublishMetric, error) {
+func waitForMetric(
+	metricsCh chan metrics.PublishMetric,
+	timeout time.Duration,
+) (metrics.PublishMetric, error) {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 

--- a/metrics/publish_metric.go
+++ b/metrics/publish_metric.go
@@ -11,10 +11,12 @@ import (
 // PublishMetric holds the information about the metric we are measuring.
 type PublishMetric struct {
 	UUID            string
-	PublishOK       bool      //did it meet the SLA?
-	PublishDate     time.Time //the time WE get the message
+	EditorialDesk   string
+	Publication     []string
+	PublishOK       bool      // did it meet the SLA?
+	PublishDate     time.Time // the time WE get the message
 	Platform        string
-	PublishInterval Interval //the interval it was actually published in, ex. (10,20)
+	PublishInterval Interval // the interval it was actually published in, ex. (10,20)
 	Config          config.MetricConfig
 	Endpoint        url.URL
 	TID             string
@@ -23,9 +25,12 @@ type PublishMetric struct {
 }
 
 func (pm PublishMetric) String() string {
-	return fmt.Sprintf("Tid: %s, UUID: %s, Platform: %s, Endpoint: %s, PublishDate: %s, Duration: %d, Succeeded: %t.",
+	return fmt.Sprintf(
+		"Tid: %s, UUID: %s, Editorial Desk: %s, Publication %v, Platform: %s, Endpoint: %s, PublishDate: %s, Duration: %d, Succeeded: %t.",
 		pm.TID,
 		pm.UUID,
+		pm.EditorialDesk,
+		pm.Publication,
 		pm.Platform,
 		pm.Config.Alias,
 		pm.PublishDate.String(),

--- a/startup.sh
+++ b/startup.sh
@@ -12,6 +12,7 @@ sed -i "s \"LISTS_URL\" \"$LISTS_URL\" " /config.json
 sed -i "s \"PAGES_URL\" \"$PAGES_URL\" " /config.json
 sed -i "s \"LIST_NOTIFICATIONS_URL\" \"$LIST_NOTIFICATIONS_URL\" " /config.json
 sed -i "s \"PAGE_NOTIFICATIONS_URL\" \"$PAGE_NOTIFICATIONS_URL\" " /config.json
+sed -i "s \"NOTIFICATIONS_PUSH_PUBLICATION_MONITOR_LIST\" \"$NOTIFICATIONS_PUSH_PUBLICATION_MONITOR_LIST\" " /config.json
 sed -i "s \"NOTIFICATIONS_URL\" \"$NOTIFICATIONS_URL\" " /config.json
 sed -i "s \"LIST_NOTIFICATIONS_PUSH_URL\" \"$LIST_NOTIFICATIONS_PUSH_URL\" " /config.json
 sed -i "s \"PAGE_NOTIFICATIONS_PUSH_URL\" \"$PAGE_NOTIFICATIONS_PUSH_URL\" " /config.json


### PR DESCRIPTION
# Description

## What

This PR intends to remedy a problem we have with excessive SLA alerts when SV content is being published to out platform. For notifications-push if the content is SV we simply skip the check. For notifications-pull this PR adds an X-Policy that allows for reading SV content.

## Why

[UPPSF-5245](https://financialtimes.atlassian.net/browse/UPPSF-5245)

## Anything, in particular, you'd like to highlight to reviewers

Please check whether my reasoning is correct, have I deduced correctly how to handle both cases.

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)
___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)


[UPPSF-5245]: https://financialtimes.atlassian.net/browse/UPPSF-5245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ