### PR TITLE
Properly enable the content checks for our ContentRelation type.

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -79,6 +79,15 @@
       ]
     },
     {
+      "endpoint": "CONTENT_RELATION_URL",
+      "granularity": 40,
+      "alias": "content-relation",
+      "health": "/__public-content-relation-api/__health",
+      "contentTypes": [
+        "application/vnd.ft-upp-content-relation+json"
+      ]
+    },
+    {
       "endpoint": "NOTIFICATIONS_URL",
       "granularity": 40,
       "alias": "notifications",

--- a/config.json.template
+++ b/config.json.template
@@ -26,7 +26,6 @@
         "application/vnd.ft-upp-audio+json",
         "application/vnd.ft-upp-clip+json",
         "application/vnd.ft-upp-clip-set+json",
-        "application/vnd.ft-upp-content-relation+json",
         "application/vnd.ft-upp-custom-code-component+json"
       ]
     },

--- a/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_dev.yaml
+++ b/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_dev.yaml
@@ -16,6 +16,7 @@ envs:
   internal_components_url: "/__document-store-api/internalcomponents/"
   lists_url: "/__public-lists-api/lists/"
   pages_url: "/__public-pages-api/pages/"
+  content_relation_url: "/__public-content-relation-api/contentrelations/"
   notifications_url: "/__notifications-rw/content/notifications?type=all"
   notifications_url_param2: "monitor=true"
   # I had to split the URL into 2 parts because I couldn't find a way to put the exact string \& in the value

--- a/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_prod.yaml
+++ b/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_prod.yaml
@@ -16,6 +16,7 @@ envs:
   internal_components_url: "/__document-store-api/internalcomponents/"
   lists_url: "/__public-lists-api/lists/"
   pages_url: "/__public-pages-api/pages/"
+  content_relation_url: "/__public-content-relation-api/contentrelations/"
   notifications_url: "/__notifications-rw/content/notifications?type=all"
   notifications_url_param2: "monitor=true"
   # I had to split the URL into 2 parts because I couldn't find a way to put the exact string \& in the value

--- a/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_staging.yaml
+++ b/helm/publish-availability-monitor/app-configs/publish-availability-monitor_eks_publish_staging.yaml
@@ -16,6 +16,7 @@ envs:
   internal_components_url: "/__document-store-api/internalcomponents/"
   lists_url: "/__public-lists-api/lists/"
   pages_url: "/__public-pages-api/pages/"
+  content_relation_url: "/__public-content-relation-api/contentrelations/"
   notifications_url: "/__notifications-rw/content/notifications?type=all"
   notifications_url_param2: "monitor=true"
   # I had to split the URL into 2 parts because I couldn't find a way to put the exact string \& in the value

--- a/helm/publish-availability-monitor/templates/deployment.yaml
+++ b/helm/publish-availability-monitor/templates/deployment.yaml
@@ -70,6 +70,8 @@ spec:
           value: "{{ .Values.envs.lists_url }}"
         - name: PAGES_URL
           value: "{{ .Values.envs.pages_url }}"
+        - name: CONTENT_RELATION_URL
+          value: "{{ .Values.envs.content_relation_url }}"
         - name: NOTIFICATIONS_PUSH_PUBLICATION_MONITOR_LIST
           value: {{ .Values.envs.notifications_push_publication_monitor_list }}
         - name: NOTIFICATIONS_URL

--- a/helm/publish-availability-monitor/values.yaml
+++ b/helm/publish-availability-monitor/values.yaml
@@ -16,6 +16,7 @@ envs:
   internal_components_url: ""
   lists_url: ""
   pages_url: ""
+  content_relation_url: ""
   notifications_url: ""
   notifications_push_url: ""
   list_notifications_url: ""

--- a/messageHandler.go
+++ b/messageHandler.go
@@ -112,7 +112,7 @@ func (h *kafkaMessageHandler) HandleMessage(msg kafka.FTMessage) {
 		"enrichedContent":          checks.NewContentCheck(hC),
 		"lists":                    checks.NewContentCheck(hC),
 		"pages":                    checks.NewContentCheck(hC),
-		"contentrelations":         checks.NewContentCheck(hC),
+		"content-relation":         checks.NewContentCheck(hC),
 		"notifications": checks.NewNotificationsCheck(
 			hC,
 			h.subscribedFeeds,

--- a/runbooks/runbook.md
+++ b/runbooks/runbook.md
@@ -42,6 +42,8 @@ The Publish Availability Monitor listens to new content messages via the Kafka t
 * The Lists Notifications /__list-notifications-rw/lists/notifications endpoint.
 * The Lists Notification Push /lists/notifications-push endpoint.
 
+* The Content Relation Public Read /__public-content-relation-api/contentrelations/ 
+
 If two of the last ten pieces of content failed any of these checks, then the PAM healthcheck will
 switch to RED and therefore cause the cluster healthchecks and good-to-go
 endpoints to show RED.

--- a/startup.sh
+++ b/startup.sh
@@ -10,6 +10,7 @@ sed -i "s \"CONTENT_COLLECTION_NEO4J_URL\" \"$CONTENT_COLLECTION_NEO4J_URL\" " /
 sed -i "s \"COMPLEMENTARY_CONTENT_URL\" \"$COMPLEMENTARY_CONTENT_URL\" " /config.json
 sed -i "s \"LISTS_URL\" \"$LISTS_URL\" " /config.json
 sed -i "s \"PAGES_URL\" \"$PAGES_URL\" " /config.json
+sed -i "s \"CONTENT_RELATION_URL\" \"$CONTENT_RELATION_URL\" " /config.json
 sed -i "s \"LIST_NOTIFICATIONS_URL\" \"$LIST_NOTIFICATIONS_URL\" " /config.json
 sed -i "s \"PAGE_NOTIFICATIONS_URL\" \"$PAGE_NOTIFICATIONS_URL\" " /config.json
 sed -i "s \"NOTIFICATIONS_PUSH_PUBLICATION_MONITOR_LIST\" \"$NOTIFICATIONS_PUSH_PUBLICATION_MONITOR_LIST\" " /config.json


### PR DESCRIPTION
# Description

## What

This PR intends to enable proper validation and monitoring of our ContentRelation type.
Basically, it comprises the necessary work to have a new configuration for publication monitoring by the PAM.

## Why

There were several errors flagged by the OpsCops rota where the PAM was trying to find a published/republished ContentRelation looking at the wrong place. This wrong place was the /content endpoint. Since we do not write ContentRelation in the standard collection in the Document Store, this would never work.

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)
___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
